### PR TITLE
질문 서비스 작업

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,68 +1,70 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.4.4'
-	id 'io.spring.dependency-management' version '1.1.7'
-	id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    id 'java'
+    id 'org.springframework.boot' version '3.4.4'
+    id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
 }
 
 group = 'com.team6'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	asciidoctorExt
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    asciidoctorExt
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
-	maven {url 'https://repo.spring.io/milestone'}
+    mavenCentral()
+    maven { url 'https://repo.spring.io/milestone' }
 }
 
 ext {
-	set('snippetsDir', file("build/generated-snippets"))
+    set('snippetsDir', file("build/generated-snippets"))
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-	testImplementation 'org.springframework.security:spring-security-test'
-	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'org.springframework.security:spring-security-test'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // H2 데이터베이스 의존성 추가
     runtimeOnly 'com.h2database:h2'
+    // spring validation 의존성 추가
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     // Spring AI
     implementation 'org.springframework.ai:spring-ai-starter-model-openai:1.0.0-M7'
 }
 
 tasks.named('test') {
-	outputs.dir snippetsDir
-	useJUnitPlatform()
+    outputs.dir snippetsDir
+    useJUnitPlatform()
 }
 
 tasks.named('asciidoctor') {
-	inputs.dir snippetsDir
-	configurations 'asciidoctorExt'
-	dependsOn test
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+    dependsOn test
 }
 
 asciidoctor {
-	baseDirFollowsSourceFile()
+    baseDirFollowsSourceFile()
 }
 
 tasks.register('copyApiDocument', Copy) {
@@ -77,7 +79,7 @@ tasks.register('copyApiDocument', Copy) {
 
 bootJar {
     dependsOn copyApiDocument
-	from("src/main/resources/static/docs") {
-		into("static/docs")
-	}
+    from("src/main/resources/static/docs") {
+        into("static/docs")
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,10 @@ dependencies {
 	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	// Spring AI
-	implementation 'org.springframework.ai:spring-ai-starter-model-openai:1.0.0-M7'
+    // H2 데이터베이스 의존성 추가
+    runtimeOnly 'com.h2database:h2'
+    // Spring AI
+    implementation 'org.springframework.ai:spring-ai-starter-model-openai:1.0.0-M7'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven {url 'https://repo.spring.io/milestone'}
 }
 
 ext {
@@ -42,6 +43,9 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Spring AI
+	implementation 'org.springframework.ai:spring-ai-starter-model-openai:1.0.0-M7'
 }
 
 tasks.named('test') {

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,3 +1,6 @@
+
 = API 문서
 :toc: left
 :sectnums:
+
+include::questions.adoc[]

--- a/src/docs/asciidoc/questions.adoc
+++ b/src/docs/asciidoc/questions.adoc
@@ -1,0 +1,20 @@
+= 질문 API
+
+== 질문 조회
+
+====
+질문을 조회하는 API입니다.
+====
+
+=== 요청 형식 (HTTP)
+[options="header"]
+|===
+| 파라미터 | 타입 | 필수 여부 | 설명
+| keyword | String | 필수 | 랜덤 질문을 가져올 키워드
+|===
+include::{snippets}/question-controller-test/get/http-request.adoc[]
+
+=== 응답 형식 (HTTP)
+include::{snippets}/question-controller-test/get/response-fields.adoc[]
+include::{snippets}/question-controller-test/get/response-body.adoc[]
+

--- a/src/main/java/com/team6/team6/Team6Application.java
+++ b/src/main/java/com/team6/team6/Team6Application.java
@@ -2,7 +2,11 @@ package com.team6.team6;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.retry.annotation.EnableRetry;
 
+@EnableRetry
+@EnableJpaAuditing
 @SpringBootApplication
 public class Team6Application {
 

--- a/src/main/java/com/team6/team6/global/ApiResponse.java
+++ b/src/main/java/com/team6/team6/global/ApiResponse.java
@@ -1,0 +1,26 @@
+package com.team6.team6.global;
+
+import org.springframework.http.HttpStatus;
+
+public record ApiResponse<T>(
+        int code,
+        HttpStatus status,
+        String message,
+        T data
+) {
+    public ApiResponse(HttpStatus status, String message, T data) {
+        this(status.value(), status, message, data);
+    }
+
+    public static <T> ApiResponse<T> of(HttpStatus httpStatus, String message, T data) {
+        return new ApiResponse<>(httpStatus, message, data);
+    }
+
+    public static <T> ApiResponse<T> of(HttpStatus httpStatus, T data) {
+        return of(httpStatus, httpStatus.name(), data);
+    }
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return of(HttpStatus.OK, data);
+    }
+}

--- a/src/main/java/com/team6/team6/global/config/AiConfig.java
+++ b/src/main/java/com/team6/team6/global/config/AiConfig.java
@@ -1,0 +1,15 @@
+package com.team6.team6.global.config;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.model.ChatModel;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AiConfig {
+
+    @Bean
+    public ChatClient chatClient(ChatModel chatModel) {
+        return ChatClient.builder(chatModel).build();
+    }
+}

--- a/src/main/java/com/team6/team6/global/entity/BaseEntity.java
+++ b/src/main/java/com/team6/team6/global/entity/BaseEntity.java
@@ -1,0 +1,21 @@
+package com.team6.team6.global.entity;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+
+}

--- a/src/main/java/com/team6/team6/global/error/exception/NotFoundException.java
+++ b/src/main/java/com/team6/team6/global/error/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.team6.team6.global.error.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/team6/team6/global/error/exception/UnauthorizedException.java
+++ b/src/main/java/com/team6/team6/global/error/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.team6.team6.global.error.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/team6/team6/global/error/exhandler/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/team6/team6/global/error/exhandler/advice/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.team6.team6.global.error.exhandler.advice;
+
+import com.team6.team6.global.ApiResponse;
+import com.team6.team6.global.error.exception.NotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(NotFoundException.class)
+    public ApiResponse<Object> handleNotFoundException(NotFoundException e) {
+        return ApiResponse.of(
+                HttpStatus.NOT_FOUND,
+                e.getMessage(),
+                null
+        );
+    }
+
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler({BindException.class, IllegalStateException.class})
+    public ApiResponse<Object> bindException(BindException e) {
+        return ApiResponse.of(
+                HttpStatus.BAD_REQUEST,
+                e.getBindingResult().getAllErrors().get(0).getDefaultMessage(),
+                e.getBindingResult().getAllErrors()
+        );
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(Exception.class)
+    public ApiResponse<Object> handleException(Exception e) {
+        return ApiResponse.of(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "서버 오류",
+                null
+        );
+    }
+
+
+}

--- a/src/main/java/com/team6/team6/global/error/exhandler/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/team6/team6/global/error/exhandler/advice/GlobalExceptionHandler.java
@@ -2,11 +2,17 @@ package com.team6.team6.global.error.exhandler.advice;
 
 import com.team6.team6.global.ApiResponse;
 import com.team6.team6.global.error.exception.NotFoundException;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -23,24 +29,65 @@ public class GlobalExceptionHandler {
 
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
-    @ExceptionHandler({BindException.class, IllegalStateException.class})
-    public ApiResponse<Object> bindException(BindException e) {
+    @ExceptionHandler(BindException.class)
+    public ApiResponse<Object> handleBindException(BindException e) {
+        List<String> errorMessages = e.getBindingResult().getAllErrors().stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.toList());
+
         return ApiResponse.of(
                 HttpStatus.BAD_REQUEST,
-                e.getBindingResult().getAllErrors().get(0).getDefaultMessage(),
-                e.getBindingResult().getAllErrors()
+                "잘못된 파라미터",
+                errorMessages.isEmpty() ? List.of("유효하지 않은 요청입니다") : errorMessages
         );
     }
 
-    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
-    @ExceptionHandler(Exception.class)
-    public ApiResponse<Object> handleException(Exception e) {
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<Object> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        List<String> errorMessages = e.getBindingResult().getAllErrors().stream()
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .collect(Collectors.toList());
+
         return ApiResponse.of(
-                HttpStatus.INTERNAL_SERVER_ERROR,
-                "서버 오류",
-                null
+                HttpStatus.BAD_REQUEST,
+                "잘못된 파라미터",
+                errorMessages.isEmpty() ? List.of("유효하지 않은 요청입니다") : errorMessages
         );
     }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(IllegalStateException.class)
+    public ApiResponse<Object> handleIllegalStateException(IllegalStateException e) {
+        List<String> errorMessages = List.of(e.getMessage());
+
+        return ApiResponse.of(
+                HttpStatus.BAD_REQUEST,
+                "잘못된 파라미터",
+                errorMessages
+        );
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ApiResponse<Object> handleHttpMessageNotReadableException() {
+        return ApiResponse.of(
+                HttpStatus.BAD_REQUEST,
+                "잘못된 파라미터",
+                List.of("요청 본문이 필요합니다")
+        );
+    }
+
+//    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+//    @ExceptionHandler(Exception.class)
+//    public ApiResponse<Object> handleException(Exception e) {
+//        return ApiResponse.of(
+//                HttpStatus.INTERNAL_SERVER_ERROR,
+//                "서버 오류",
+//                null
+//        );
+//    }
 
 
 }

--- a/src/main/java/com/team6/team6/question/controller/QuestionController.java
+++ b/src/main/java/com/team6/team6/question/controller/QuestionController.java
@@ -1,0 +1,31 @@
+package com.team6.team6.question.controller;
+
+import com.team6.team6.global.ApiResponse;
+import com.team6.team6.question.dto.QuestionResponse;
+import com.team6.team6.question.service.QuestionService;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/questions")
+@Validated
+public class QuestionController {
+
+    private final QuestionService questionService;
+
+    @GetMapping
+    public ApiResponse<List<QuestionResponse>> getRandomQuestions(
+            @RequestParam @NotBlank(message = "키워드는 비어 있을 수 없습니다.") String keyword
+    ) {
+        List<QuestionResponse> questions = questionService.getRandomQuestions(keyword);
+        return ApiResponse.ok(questions);
+    }
+}

--- a/src/main/java/com/team6/team6/question/domain/KeywordLockManager.java
+++ b/src/main/java/com/team6/team6/question/domain/KeywordLockManager.java
@@ -1,0 +1,16 @@
+package com.team6.team6.question.domain;
+
+public interface KeywordLockManager {
+
+    /**
+     * 주어진 키워드에 대해 잠금을 시도한다.
+     * 잠금에 성공한 경우 true, 이미 잠겨있으면 false
+     */
+    boolean tryLock(String keyword);
+
+    /**
+     * 주어진 키워드에 대한 잠금을 해제한다.
+     */
+    void unlock(String keyword);
+}
+

--- a/src/main/java/com/team6/team6/question/domain/QuestionGenerator.java
+++ b/src/main/java/com/team6/team6/question/domain/QuestionGenerator.java
@@ -1,0 +1,7 @@
+package com.team6.team6.question.domain;
+
+import java.util.List;
+
+public interface QuestionGenerator {
+    List<String> generateQuestions(String keyword);
+}

--- a/src/main/java/com/team6/team6/question/domain/QuestionRepository.java
+++ b/src/main/java/com/team6/team6/question/domain/QuestionRepository.java
@@ -1,0 +1,10 @@
+package com.team6.team6.question.domain;
+
+import com.team6.team6.question.entity.Question;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+    boolean existsByKeyword(String keyword);
+}

--- a/src/main/java/com/team6/team6/question/domain/QuestionRepository.java
+++ b/src/main/java/com/team6/team6/question/domain/QuestionRepository.java
@@ -4,7 +4,10 @@ import com.team6.team6.question.entity.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
     boolean existsByKeyword(String keyword);
+    List<Question> findAllByKeyword(String keyword);
 }

--- a/src/main/java/com/team6/team6/question/domain/Questions.java
+++ b/src/main/java/com/team6/team6/question/domain/Questions.java
@@ -1,0 +1,35 @@
+package com.team6.team6.question.domain;
+
+import com.team6.team6.question.entity.Question;
+import lombok.Value;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Value
+public class Questions {
+
+    List<Question> values;
+
+    public static Questions of(List<Question> list) {
+        return new Questions(List.copyOf(list));
+    }
+
+    public List<Question> getRandomSubset(int count) {
+        if (values.size() <= count) return values;
+
+        List<Question> copy = new ArrayList<>(values);
+        Collections.shuffle(copy);
+        return copy.subList(0, count);
+    }
+
+    public boolean isEmpty() {
+        return values.isEmpty();
+    }
+
+    public int size() {
+        return values.size();
+    }
+}
+

--- a/src/main/java/com/team6/team6/question/dto/QuestionResponse.java
+++ b/src/main/java/com/team6/team6/question/dto/QuestionResponse.java
@@ -1,0 +1,9 @@
+package com.team6.team6.question.dto;
+
+import com.team6.team6.question.entity.Question;
+
+public record QuestionResponse(Long id, String keyword, String question) {
+    public static QuestionResponse from(Question question) {
+        return new QuestionResponse(question.getId(), question.getKeyword(), question.getQuestion());
+    }
+}

--- a/src/main/java/com/team6/team6/question/entity/Question.java
+++ b/src/main/java/com/team6/team6/question/entity/Question.java
@@ -1,0 +1,36 @@
+package com.team6.team6.question.entity;
+
+import com.team6.team6.global.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Question extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String keyword;
+    private String question;
+
+    @Builder
+    private Question(String keyword, String question) {
+        this.question = question;
+        this.keyword = keyword;
+    }
+
+    public static Question of(String keyword, String question) {
+        return Question.builder()
+                .keyword(keyword)
+                .question(question)
+                .build();
+    }
+}

--- a/src/main/java/com/team6/team6/question/infrastructure/InMemoryKeywordLockManager.java
+++ b/src/main/java/com/team6/team6/question/infrastructure/InMemoryKeywordLockManager.java
@@ -1,0 +1,23 @@
+package com.team6.team6.question.infrastructure;
+
+import com.team6.team6.question.domain.KeywordLockManager;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+@Component
+public class InMemoryKeywordLockManager implements KeywordLockManager {
+
+    private final ConcurrentMap<String, Boolean> lockMap = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean tryLock(String keyword) {
+        return lockMap.putIfAbsent(keyword, true) == null;
+    }
+
+    @Override
+    public void unlock(String keyword) {
+        lockMap.remove(keyword);
+    }
+}

--- a/src/main/java/com/team6/team6/question/infrastructure/OpenAiQuestionGenerator.java
+++ b/src/main/java/com/team6/team6/question/infrastructure/OpenAiQuestionGenerator.java
@@ -1,0 +1,51 @@
+package com.team6.team6.question.infrastructure;
+
+import com.team6.team6.question.domain.QuestionGenerator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class OpenAiQuestionGenerator implements QuestionGenerator {
+
+    private final ChatClient chatClient;
+
+    private static final PromptTemplate PROMPT_TEMPLATE = new PromptTemplate("""
+                키워드: {keyword}
+
+                이 키워드를 주제로 한, 처음 만난 사람들이 편하게 이야기 나눌 수 있도록 가벼운 질문 20개를 만들어줘.
+                형식은 번호 없이 한 줄에 하나씩, 자연스럽게 구어체로 작성해줘.
+            """
+    );
+
+    @Override
+    public List<String> generateQuestions(String keyword) {
+        Prompt prompt = PROMPT_TEMPLATE.create(Map.of("keyword", keyword));
+
+        try {
+            String response = chatClient.prompt(prompt)
+                    .call()
+                    .content();
+
+            return parseQuestions(response);
+        } catch (Exception e) {
+            throw new RuntimeException("OpenAI 질문 생성 실패: " + e.getMessage(), e);
+        }
+    }
+
+    private List<String> parseQuestions(String response) {
+        return Arrays.stream(response.split("\n"))
+                .map(line -> line.replaceAll("^\\d+[.)]?\\s*", "").trim()) // 숫자 제거
+                .filter(s -> !s.isBlank())
+                .collect(Collectors.toList());
+    }
+}
+

--- a/src/main/java/com/team6/team6/question/infrastructure/OpenAiQuestionGenerator.java
+++ b/src/main/java/com/team6/team6/question/infrastructure/OpenAiQuestionGenerator.java
@@ -19,10 +19,18 @@ public class OpenAiQuestionGenerator implements QuestionGenerator {
     private final ChatClient chatClient;
 
     private static final PromptTemplate PROMPT_TEMPLATE = new PromptTemplate("""
-                키워드: {keyword}
+            키워드: {keyword}
 
-                이 키워드를 주제로 한, 처음 만난 사람들이 편하게 이야기 나눌 수 있도록 가벼운 질문 20개를 만들어줘.
-                형식은 번호 없이 한 줄에 하나씩, 자연스럽게 구어체로 작성해줘.
+            이 키워드를 주제로, 처음 만난 사람들이 편하게 이야기 나눌 수 있도록 대화형 질문 20개를 만들어줘.
+                        
+            아래 기준을 지켜줘:
+            - 너무 딱딱하거나 교과서적인 말투는 피하고, 자연스럽고 구어체로 작성해
+            - 경험, 취향, 감정을 물을 수 있는 질문이 좋고, '너라면 어때?' 식의 접근도 괜찮아
+            - 질문 하나당 한 줄로 만들어줘
+            - 숫자나 기호 없이 질문 내용만 출력해
+
+            예시:
+            롤에서 맞라인으로 나왔을 때 가장 싫은 챔피언은?
             """
     );
 

--- a/src/main/java/com/team6/team6/question/service/QuestionService.java
+++ b/src/main/java/com/team6/team6/question/service/QuestionService.java
@@ -1,5 +1,6 @@
 package com.team6.team6.question.service;
 
+import com.team6.team6.global.error.exception.NotFoundException;
 import com.team6.team6.question.domain.KeywordLockManager;
 import com.team6.team6.question.domain.QuestionGenerator;
 import com.team6.team6.question.domain.QuestionRepository;
@@ -41,6 +42,9 @@ public class QuestionService {
 
     public List<QuestionResponse> getRandomQuestions(String keyword) {
         Questions questions = Questions.of(questionRepository.findAllByKeyword(keyword));
+        if (questions.isEmpty()) {
+            throw new NotFoundException("해당 키워드에 대한 질문이 존재하지 않습니다: " + keyword);
+        }
         return questions.getRandomSubset(DEFAULT_QUESTION_COUNT).stream()
                 .map(QuestionResponse::from)
                 .toList();

--- a/src/main/java/com/team6/team6/question/service/QuestionService.java
+++ b/src/main/java/com/team6/team6/question/service/QuestionService.java
@@ -1,5 +1,6 @@
 package com.team6.team6.question.service;
 
+import com.team6.team6.question.domain.KeywordLockManager;
 import com.team6.team6.question.domain.QuestionGenerator;
 import com.team6.team6.question.domain.QuestionRepository;
 import com.team6.team6.question.entity.Question;
@@ -16,19 +17,23 @@ public class QuestionService {
 
     private final QuestionRepository questionRepository;
     private final QuestionGenerator questionGenerator;
+    private final KeywordLockManager lockManager;
 
     @Async
     public void generateQuestions(String keyword) {
-        if (questionRepository.existsByKeyword(keyword)) {
+        if (questionRepository.existsByKeyword(keyword) || !lockManager.tryLock(keyword)) {
             return;
         }
 
-        List<String> generated = questionGenerator.generateQuestions(keyword);
-        List<Question> questions = generated.stream()
-                .map(q -> Question.of(keyword, q))
-                .toList();
-
-        questionRepository.saveAll(questions);
+        try {
+            List<String> generated = questionGenerator.generateQuestions(keyword);
+            List<Question> questions = generated.stream()
+                    .map(q -> Question.of(keyword, q))
+                    .toList();
+            questionRepository.saveAll(questions);
+        } finally {
+            lockManager.unlock(keyword);
+        }
     }
 
     public List<Question> getRandomQuestions(String keyword) {

--- a/src/main/java/com/team6/team6/question/service/QuestionService.java
+++ b/src/main/java/com/team6/team6/question/service/QuestionService.java
@@ -3,17 +3,20 @@ package com.team6.team6.question.service;
 import com.team6.team6.question.domain.KeywordLockManager;
 import com.team6.team6.question.domain.QuestionGenerator;
 import com.team6.team6.question.domain.QuestionRepository;
+import com.team6.team6.question.domain.Questions;
+import com.team6.team6.question.dto.QuestionResponse;
 import com.team6.team6.question.entity.Question;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class QuestionService {
+
+    private static final int DEFAULT_QUESTION_COUNT = 10;
 
     private final QuestionRepository questionRepository;
     private final QuestionGenerator questionGenerator;
@@ -36,12 +39,10 @@ public class QuestionService {
         }
     }
 
-    public List<Question> getRandomQuestions(String keyword) {
-        List<Question> all = questionRepository.findAllByKeyword(keyword);
-
-        if (all.size() <= 10) return all;
-
-        Collections.shuffle(all);
-        return all.subList(0, 10);
+    public List<QuestionResponse> getRandomQuestions(String keyword) {
+        Questions questions = Questions.of(questionRepository.findAllByKeyword(keyword));
+        return questions.getRandomSubset(DEFAULT_QUESTION_COUNT).stream()
+                .map(QuestionResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/com/team6/team6/question/service/QuestionService.java
+++ b/src/main/java/com/team6/team6/question/service/QuestionService.java
@@ -1,0 +1,32 @@
+package com.team6.team6.question.service;
+
+import com.team6.team6.question.domain.QuestionGenerator;
+import com.team6.team6.question.domain.QuestionRepository;
+import com.team6.team6.question.entity.Question;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+
+    private final QuestionRepository questionRepository;
+    private final QuestionGenerator questionGenerator;
+
+    @Async
+    public void generateQuestions(String keyword) {
+        if (questionRepository.existsByKeyword(keyword)) {
+            return;
+        }
+
+        List<String> generated = questionGenerator.generateQuestions(keyword);
+        List<Question> questions = generated.stream()
+                .map(q -> Question.of(keyword, q))
+                .toList();
+
+        questionRepository.saveAll(questions);
+    }
+}

--- a/src/main/java/com/team6/team6/question/service/QuestionService.java
+++ b/src/main/java/com/team6/team6/question/service/QuestionService.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -28,5 +29,14 @@ public class QuestionService {
                 .toList();
 
         questionRepository.saveAll(questions);
+    }
+
+    public List<Question> getRandomQuestions(String keyword) {
+        List<Question> all = questionRepository.findAllByKeyword(keyword);
+
+        if (all.size() <= 10) return all;
+
+        Collections.shuffle(all);
+        return all.subList(0, 10);
     }
 }

--- a/src/main/java/com/team6/team6/question/service/QuestionService.java
+++ b/src/main/java/com/team6/team6/question/service/QuestionService.java
@@ -10,6 +10,7 @@ import com.team6.team6.question.entity.Question;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -23,6 +24,7 @@ public class QuestionService {
     private final QuestionGenerator questionGenerator;
     private final KeywordLockManager lockManager;
 
+    @Transactional
     @Async
     public void generateQuestions(String keyword) {
         if (questionRepository.existsByKeyword(keyword) || !lockManager.tryLock(keyword)) {

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,14 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL;
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        format_sql: true
+    show-sql: true

--- a/src/test/java/com/team6/team6/global/TestSecurityConfig.java
+++ b/src/test/java/com/team6/team6/global/TestSecurityConfig.java
@@ -1,0 +1,19 @@
+package com.team6.team6.global;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll()
+                )
+                .build();
+    }
+}

--- a/src/test/java/com/team6/team6/question/controller/QuestionControllerTest.java
+++ b/src/test/java/com/team6/team6/question/controller/QuestionControllerTest.java
@@ -1,0 +1,70 @@
+package com.team6.team6.question.controller;
+
+import com.team6.team6.global.TestSecurityConfig;
+import com.team6.team6.question.dto.QuestionResponse;
+import com.team6.team6.question.service.QuestionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static com.team6.team6.global.CustomRestDocsHandler.customDocument;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = QuestionController.class)
+@AutoConfigureRestDocs
+@Import(TestSecurityConfig.class)
+class QuestionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockitoBean
+    private QuestionService questionService;
+
+    @Test
+    void 정상_요청_테스트() throws Exception {
+        // given
+        String keyword = "LOL";
+        List<QuestionResponse> responseList = List.of(
+                new QuestionResponse(1L, keyword, "Q1"),
+                new QuestionResponse(2L, keyword, "Q2")
+        );
+        given(questionService.getRandomQuestions(keyword)).willReturn(responseList);
+
+        // when & then
+        mockMvc.perform(get("/questions")
+                        .param("keyword", keyword))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(customDocument(
+                        "get",
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                        .description("결과 코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING)
+                                        .description("HTTP 상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("응답 메시지"),
+                                fieldWithPath("data").description("질문 목록"),
+                                fieldWithPath("data[].id").description("질문 ID"),
+                                fieldWithPath("data[].keyword").description("질문 키워드"),
+                                fieldWithPath("data[].question").description("질문 내용")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/team6/team6/question/domain/QuestionsTest.java
+++ b/src/test/java/com/team6/team6/question/domain/QuestionsTest.java
@@ -1,0 +1,49 @@
+package com.team6.team6.question.domain;
+
+import com.team6.team6.question.entity.Question;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class QuestionsTest {
+
+    @Test
+    void getRandomSubset_요청_수보다_작거나_같으면_전체_반환() {
+        // given
+        List<Question> list = List.of(
+                Question.of("test", "Q1"),
+                Question.of("test", "Q2")
+        );
+        Questions questions = Questions.of(list);
+
+        // when
+        List<Question> subset = questions.getRandomSubset(5);
+
+        // then
+        assertThat(subset).containsExactlyInAnyOrderElementsOf(list);
+    }
+
+    @Test
+    void getRandomSubset_요청_수보다_많으면_랜덤_10개_반환() {
+        // given
+        List<Question> list = new ArrayList<>();
+        for (int i = 1; i <= 20; i++) {
+            list.add(Question.of("test", "Q" + i));
+        }
+        Questions questions = Questions.of(list);
+
+        // when
+        List<Question> subset = questions.getRandomSubset(10);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(subset).hasSize(10);
+            softly.assertThat(list).containsAll(subset);
+        });
+    }
+}
+

--- a/src/test/java/com/team6/team6/question/domain/SimulatedLatencyQuestionGenerator.java
+++ b/src/test/java/com/team6/team6/question/domain/SimulatedLatencyQuestionGenerator.java
@@ -2,7 +2,7 @@ package com.team6.team6.question.domain;
 
 import java.util.List;
 
-public class TestQuestionGenerator implements QuestionGenerator {
+public class SimulatedLatencyQuestionGenerator implements QuestionGenerator {
 
     @Override
     public List<String> generateQuestions(String keyword) {

--- a/src/test/java/com/team6/team6/question/domain/TestQuestionGenerator.java
+++ b/src/test/java/com/team6/team6/question/domain/TestQuestionGenerator.java
@@ -1,0 +1,16 @@
+package com.team6.team6.question.domain;
+
+import java.util.List;
+
+public class TestQuestionGenerator implements QuestionGenerator {
+
+    @Override
+    public List<String> generateQuestions(String keyword) {
+        try {
+            Thread.sleep(2000); // 비동기 여부 확인용
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return List.of("Q1", "Q2", "Q3");
+    }
+}

--- a/src/test/java/com/team6/team6/question/infrastructure/InMemoryKeywordLockManagerTest.java
+++ b/src/test/java/com/team6/team6/question/infrastructure/InMemoryKeywordLockManagerTest.java
@@ -1,0 +1,99 @@
+package com.team6.team6.question.infrastructure;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class InMemoryKeywordLockManagerTest {
+
+    private InMemoryKeywordLockManager lockManager;
+
+    @BeforeEach
+    void setUp() {
+        lockManager = new InMemoryKeywordLockManager();
+    }
+
+    @Test
+    void try_lock_테스트() {
+        // given
+        String keyword = "LOL";
+
+        // when
+        boolean first = lockManager.tryLock(keyword);
+        boolean second = lockManager.tryLock(keyword);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(first).isTrue();
+            softly.assertThat(second).isFalse();
+        });
+    }
+
+    @Test
+    void unlock_후_다시_tryLock_시도_테스트() {
+        // given
+        String keyword = "LOL";
+
+        // when
+        boolean first = lockManager.tryLock(keyword);
+        lockManager.unlock(keyword);
+        boolean second = lockManager.tryLock(keyword);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(first).isTrue();
+            softly.assertThat(second).isTrue();
+        });
+    }
+
+    @Test
+    void 다른_키워드_독립_잠금_테스트() {
+        // given
+        String keyword1 = "LOL";
+        String keyword2 = "Netflix";
+
+        // when
+        boolean lock1 = lockManager.tryLock(keyword1);
+        boolean lock2 = lockManager.tryLock(keyword2);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(lock1).isTrue();
+            softly.assertThat(lock2).isTrue();
+        });
+    }
+
+    @Test
+    void tryLock_동시에_호출하면_하나는_성공_하나는_실패한다() throws InterruptedException, ExecutionException {
+        // given
+        String keyword = "LOL";
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch readyLatch = new CountDownLatch(2);
+        CountDownLatch startLatch = new CountDownLatch(1);
+
+        Callable<Boolean> task = () -> {
+            readyLatch.countDown();     // 두 스레드가 모두 준비될 때까지 대기
+            startLatch.await();         // 동시에 시작
+            return lockManager.tryLock(keyword);
+        };
+
+        // when
+        Future<Boolean> result1 = executor.submit(task);
+        Future<Boolean> result2 = executor.submit(task);
+
+        // 두 스레드 준비될 때까지 대기 후 시작
+        readyLatch.await();
+        startLatch.countDown();
+
+        // then
+        boolean res1 = result1.get();
+        boolean res2 = result2.get();
+        assertThat(res1 ^ res2).isTrue(); // 하나만 true일 때 XOR 결과가 true
+
+        executor.shutdown();
+    }
+}

--- a/src/test/java/com/team6/team6/question/infrastructure/OpenAiQuestionGeneratorTest.java
+++ b/src/test/java/com/team6/team6/question/infrastructure/OpenAiQuestionGeneratorTest.java
@@ -1,0 +1,73 @@
+package com.team6.team6.question.infrastructure;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.client.ChatClient.CallResponseSpec;
+import org.springframework.ai.chat.client.ChatClient.ChatClientRequestSpec;
+import org.springframework.ai.chat.prompt.Prompt;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OpenAiQuestionGeneratorTest {
+
+    @Mock
+    private ChatClient chatClient;
+
+    @InjectMocks
+    private OpenAiQuestionGenerator questionGenerator;
+
+    @Test
+    void 결과_반환_테스트() {
+        // given
+        String keyword = "LOL";
+        String aiResponse = """
+                롤에서 맞라인으로 나왔을 때 가장 싫은 챔피언은?
+                가장 좋아하는 챔피언은 누구야?
+                승률은 중요하게 생각해?
+                """;
+
+        ChatClientRequestSpec requestSpec = mock(ChatClientRequestSpec.class);
+        CallResponseSpec response = mock(CallResponseSpec.class);
+
+        // when
+        when(chatClient.prompt(any(Prompt.class))).thenReturn(requestSpec);
+        when(requestSpec.call()).thenReturn(response);
+        when(response.content()).thenReturn(aiResponse);
+        List<String> questions = questionGenerator.generateQuestions(keyword);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(questions).hasSize(3);
+            softly.assertThat(questions).containsExactly(
+                    "롤에서 맞라인으로 나왔을 때 가장 싫은 챔피언은?",
+                    "가장 좋아하는 챔피언은 누구야?",
+                    "승률은 중요하게 생각해?"
+            );
+        });
+    }
+
+    @Test
+    void chatClient_호출_중_예외_발생_테스트() {
+        // given
+        String keyword = "LOL";
+
+        // when
+        when(chatClient.prompt(any(Prompt.class))).thenThrow(new IllegalStateException("API 실패"));
+
+        // then
+        assertThatThrownBy(() -> questionGenerator.generateQuestions(keyword))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("OpenAI 질문 생성 실패");
+    }
+}

--- a/src/test/java/com/team6/team6/question/service/QuestionServiceAsyncTest.java
+++ b/src/test/java/com/team6/team6/question/service/QuestionServiceAsyncTest.java
@@ -11,10 +11,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
 @SpringBootTest
 @TestPropertySource(properties = {
@@ -33,7 +39,7 @@ class QuestionServiceAsyncTest {
         }
     }
 
-    @MockitoBean
+    @MockitoSpyBean
     private QuestionRepository questionRepository;
 
     @Autowired
@@ -52,6 +58,39 @@ class QuestionServiceAsyncTest {
 
         // then
         assertThat(elapsed).isLessThan(500L); // 0.5초 이내에 반환되어야 함
+    }
+
+    @Test
+    void 동시에_두_요청이_와도_질문은_한번만_생성된다() throws Exception {
+        // given
+        String keyword = "LOL";
+        given(questionRepository.existsByKeyword(keyword)).willReturn(false);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+
+        Runnable task = () -> {
+            try {
+                ready.countDown();
+                start.await();
+                questionService.generateQuestions(keyword);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        };
+
+        // when - 두 스레드 동시에 실행
+        executor.submit(task);
+        executor.submit(task);
+
+        ready.await();  // 두 스레드 준비 대기
+        start.countDown(); // 동시에 실행 시작
+        executor.awaitTermination(3, TimeUnit.SECONDS);
+
+        // then
+        verify(questionRepository, times(1)).saveAll(anyList());
+        executor.shutdown();
     }
 }
 

--- a/src/test/java/com/team6/team6/question/service/QuestionServiceAsyncTest.java
+++ b/src/test/java/com/team6/team6/question/service/QuestionServiceAsyncTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -20,6 +21,7 @@ import static org.mockito.BDDMockito.given;
         "spring.task.execution.pool.core-size=4",
         "spring.task.execution.pool.max-size=8"
 })
+@ActiveProfiles("test")
 class QuestionServiceAsyncTest {
 
     @TestConfiguration

--- a/src/test/java/com/team6/team6/question/service/QuestionServiceAsyncTest.java
+++ b/src/test/java/com/team6/team6/question/service/QuestionServiceAsyncTest.java
@@ -1,5 +1,6 @@
 package com.team6.team6.question.service;
 
+import com.team6.team6.global.error.exception.NotFoundException;
 import com.team6.team6.question.domain.QuestionGenerator;
 import com.team6.team6.question.domain.QuestionRepository;
 import com.team6.team6.question.domain.TestQuestionGenerator;
@@ -13,12 +14,14 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -91,6 +94,18 @@ class QuestionServiceAsyncTest {
         // then
         verify(questionRepository, times(1)).saveAll(anyList());
         executor.shutdown();
+    }
+
+    @Test
+    void Question이_없을_때_예외_처리_테스트() {
+        // given
+        String keyword = "LOL";
+        given(questionRepository.findAllByKeyword(keyword)).willReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> questionService.getRandomQuestions(keyword))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("해당 키워드에 대한 질문이 존재하지 않습니다");
     }
 }
 

--- a/src/test/java/com/team6/team6/question/service/QuestionServiceAsyncTest.java
+++ b/src/test/java/com/team6/team6/question/service/QuestionServiceAsyncTest.java
@@ -1,0 +1,55 @@
+package com.team6.team6.question.service;
+
+import com.team6.team6.question.domain.QuestionGenerator;
+import com.team6.team6.question.domain.QuestionRepository;
+import com.team6.team6.question.domain.TestQuestionGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+        "spring.task.execution.pool.core-size=4",
+        "spring.task.execution.pool.max-size=8"
+})
+class QuestionServiceAsyncTest {
+
+    @TestConfiguration
+    @EnableAsync
+    static class TestConfig {
+        @Bean
+        public QuestionGenerator questionGenerator() {
+            return new TestQuestionGenerator();
+        }
+    }
+
+    @MockitoBean
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private QuestionService questionService;
+
+    @Test
+    void generateQuestions는_비동기로_즉시_반환된다() {
+        // given
+        String keyword = "LOL";
+        given(questionRepository.existsByKeyword(keyword)).willReturn(false);
+
+        // when
+        long startTime = System.currentTimeMillis();
+        questionService.generateQuestions(keyword);
+        long elapsed = System.currentTimeMillis() - startTime;
+
+        // then
+        assertThat(elapsed).isLessThan(500L); // 0.5초 이내에 반환되어야 함
+    }
+}
+

--- a/src/test/java/com/team6/team6/question/service/QuestionServiceAsyncTest.java
+++ b/src/test/java/com/team6/team6/question/service/QuestionServiceAsyncTest.java
@@ -3,7 +3,7 @@ package com.team6.team6.question.service;
 import com.team6.team6.global.error.exception.NotFoundException;
 import com.team6.team6.question.domain.QuestionGenerator;
 import com.team6.team6.question.domain.QuestionRepository;
-import com.team6.team6.question.domain.TestQuestionGenerator;
+import com.team6.team6.question.domain.SimulatedLatencyQuestionGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -38,7 +38,7 @@ class QuestionServiceAsyncTest {
     static class TestConfig {
         @Bean
         public QuestionGenerator questionGenerator() {
-            return new TestQuestionGenerator();
+            return new SimulatedLatencyQuestionGenerator();
         }
     }
 

--- a/src/test/java/com/team6/team6/question/service/QuestionServiceNonAsyncTest.java
+++ b/src/test/java/com/team6/team6/question/service/QuestionServiceNonAsyncTest.java
@@ -1,0 +1,52 @@
+package com.team6.team6.question.service;
+
+import com.team6.team6.question.domain.QuestionGenerator;
+import com.team6.team6.question.domain.QuestionRepository;
+import com.team6.team6.question.domain.TestQuestionGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+        "spring.task.execution.pool.core-size=4",
+        "spring.task.execution.pool.max-size=8"
+})
+public class QuestionServiceNonAsyncTest {
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        public QuestionGenerator questionGenerator() {
+            return new TestQuestionGenerator();
+        }
+    }
+
+    @MockitoBean
+    private QuestionRepository questionRepository;
+
+    @Autowired
+    private QuestionService questionService;
+
+    @Test
+    void generateIfNotExists_는_비동기_미설정시_바로_반환되지_않는다() {
+        // given
+        String keyword = "LOL";
+        given(questionRepository.existsByKeyword(keyword)).willReturn(false);
+
+        // when
+        long startTime = System.currentTimeMillis();
+        questionService.generateQuestions(keyword);
+        long elapsed = System.currentTimeMillis() - startTime;
+
+        // then
+        assertThat(elapsed).isGreaterThanOrEqualTo(2000L); // 동기로 2초 이상 걸려야 함
+    }
+}

--- a/src/test/java/com/team6/team6/question/service/QuestionServiceNonAsyncTest.java
+++ b/src/test/java/com/team6/team6/question/service/QuestionServiceNonAsyncTest.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
@@ -19,6 +20,7 @@ import static org.mockito.BDDMockito.given;
         "spring.task.execution.pool.core-size=4",
         "spring.task.execution.pool.max-size=8"
 })
+@ActiveProfiles("test")
 public class QuestionServiceNonAsyncTest {
 
     @TestConfiguration

--- a/src/test/java/com/team6/team6/question/service/QuestionServiceNonAsyncTest.java
+++ b/src/test/java/com/team6/team6/question/service/QuestionServiceNonAsyncTest.java
@@ -2,7 +2,7 @@ package com.team6.team6.question.service;
 
 import com.team6.team6.question.domain.QuestionGenerator;
 import com.team6.team6.question.domain.QuestionRepository;
-import com.team6.team6.question.domain.TestQuestionGenerator;
+import com.team6.team6.question.domain.SimulatedLatencyQuestionGenerator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -27,7 +27,7 @@ public class QuestionServiceNonAsyncTest {
     static class TestConfig {
         @Bean
         public QuestionGenerator questionGenerator() {
-            return new TestQuestionGenerator();
+            return new SimulatedLatencyQuestionGenerator();
         }
     }
 


### PR DESCRIPTION
## 질문 서비스 작업
- [X] 질문 생성 시 비동기 처리
- [X] 질문 생성 시 동시성 제어 적용
- [X] Questions 일급 컬렉션 분리
- [X] 비동기 및 동시성 제어 테스트 추가

## 🔨 작업 사항 

### 질문 서비스 비동기 처리
`문제 상황`
- 질문 생성은 시간이 오래 걸릴 수 있으며, 사용자 요청 흐름을 막지 않고 비동기로 처리할 필요가 있었음.

`해결 방법`
- @Async 어노테이션을 통해 질문 생성을 별도 스레드에서 비동기적으로 실행
- 비동기 메서드인 generateQuestions를 별도 서비스 메서드로 분리하여 적용
- 테스트 환경에서는 TestConfiguration을 통해 비동기 적용 및 미적용을 각각 분리하여 테스트 수행
```java
@Transactional
@Async
public void generateQuestions(String keyword) {
    if (questionRepository.existsByKeyword(keyword) || !lockManager.tryLock(keyword)) {
        return;
    }

    try {
        List<String> generated = questionGenerator.generateQuestions(keyword);
        List<Question> questions = generated.stream()
                .map(q -> Question.of(keyword, q))
                .toList();
        questionRepository.saveAll(questions);
    } finally {
        lockManager.unlock(keyword);
    }
}
```

### 질문 생성 동시성 제어
`문제 상황`
- 다수의 사용자가 동시에 같은 키워드로 질문 생성 요청을 할 경우 중복 생성 문제가 발생할 수 있었음.

`해결 방법`
- KeywordGenerationLockManager 인터페이스를 통해 동시성 제어 추상화
- 단일 서버에서는 ConcurrentHashMap 기반 InMemoryKeywordGenerationLockManager를 사용해 동시 접근을 제어
- 락 획득 실패 시 질문 생성을 건너뛰고 즉시 반환

```java
@Override
public boolean tryLock(String keyword) {
    return lockMap.putIfAbsent(keyword, true) == null;
}

@Override
public void unlock(String keyword) {
    lockMap.remove(keyword);
}
```

### 동시성 제어 테스트
```java
    @Test
    void 동시에_두_요청이_와도_질문은_한번만_생성된다() throws Exception {
        // given
        String keyword = "LOL";
        given(questionRepository.existsByKeyword(keyword)).willReturn(false);

        ExecutorService executor = Executors.newFixedThreadPool(2);
        CountDownLatch ready = new CountDownLatch(2);
        CountDownLatch start = new CountDownLatch(1);

        Runnable task = () -> {
            try {
                ready.countDown();
                start.await();
                questionService.generateQuestions(keyword);
            } catch (InterruptedException e) {
                Thread.currentThread().interrupt();
            }
        };

        // when - 두 스레드 동시에 실행
        executor.submit(task);
        executor.submit(task);

        ready.await();  // 두 스레드 준비 대기
        start.countDown(); // 동시에 실행 시작
        executor.awaitTermination(3, TimeUnit.SECONDS);

        // then
        verify(questionRepository, times(1)).saveAll(anyList());
        executor.shutdown();
    }
```

### Questions 일급 컬렉션 분리

`문제 상황`
- 서비스 단에서 List<Question>를 직접 다루고 있어, 질문 리스트에 대한 책임과 로직이 흩어져 있었음.

`해결 방법`
- Questions 일급 컬렉션을 생성하여 질문 리스트를 캡슐화
- 랜덤 10개 추출 등의 비즈니스 로직을 Questions 객체 내부로 이동하여 객체지향적인 설계 적용

```java
@Value
public class Questions {
    List<Question> values;

    public List<Question> getRandomSubset(int count) {
        if (values.size() <= count) return values;
        List<Question> copy = new ArrayList<>(values);
        Collections.shuffle(copy);
        return copy.subList(0, count);
    }
}
```
