### PR TITLE
회원 관련 작업 진행

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -12,3 +12,4 @@
 API 명세서입니다. 각 항목별 예시와 요청/응답 샘플을 제공합니다.
 
 include::room.adoc[]
+include::member.adoc[]

--- a/src/docs/asciidoc/member.adoc
+++ b/src/docs/asciidoc/member.adoc
@@ -1,0 +1,33 @@
+= 회원 API
+:snippetsDir: ../../../build/generated-snippets
+
+== 회원 가입/로그인
+
+====
+회원 가입 또는 로그인을 처리하는 API입니다.
+스프링의 세션 기반 인증을 사용하므로, 로그인 이후 요청에는 별도로 인증 정보를 포함할 필요가 없습니다.
+====
+
+=== 요청 형식 (HTTP)
+include::{snippetsDir}/member-controller-docs-test/join-or-login/http-request.adoc[]
+include::{snippetsDir}/member-controller-docs-test/join-or-login/request-fields.adoc[]
+
+=== 응답 형식 (HTTP)
+include::{snippetsDir}/member-controller-docs-test/join-or-login/http-response.adoc[]
+include::{snippetsDir}/member-controller-docs-test/join-or-login/response-fields.adoc[]
+
+'''
+
+== 회원 가입/로그인 유효성 검증 실패
+
+====
+회원 가입 또는 로그인 시 유효성 검증에 실패한 경우의 API 응답입니다.
+====
+
+=== 요청 형식 (HTTP)
+include::{snippetsDir}/member-controller-docs-test/join-or-login-validation-failure/http-request.adoc[]
+include::{snippetsDir}/member-controller-docs-test/join-or-login-validation-failure/request-fields.adoc[]
+
+=== 응답 형식 (HTTP)
+include::{snippetsDir}/member-controller-docs-test/join-or-login-validation-failure/http-response.adoc[]
+include::{snippetsDir}/member-controller-docs-test/join-or-login-validation-failure/response-body.adoc[]

--- a/src/main/java/com/team6/team6/global/config/SecurityConfig.java
+++ b/src/main/java/com/team6/team6/global/config/SecurityConfig.java
@@ -2,9 +2,12 @@ package com.team6.team6.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -14,13 +17,26 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(AbstractHttpConfigurer::disable) // CSRF 보호 비활성화 (필요 시 유지)
+                .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .anyRequest().permitAll() // 모든 요청 허용
+                        .requestMatchers("/rooms/*/member").permitAll() // 회원가입/로그인은 허용
+                        .requestMatchers(HttpMethod.POST, "/rooms").permitAll() // 방 생성은 허용
+                        .requestMatchers(HttpMethod.GET, "/rooms/*").authenticated() // 방 조회는 인증 필요
+                        .requestMatchers(HttpMethod.PATCH, "/rooms/*/close").authenticated() // 방 종료는 인증 필요
+                        .anyRequest().authenticated()
                 )
-                .formLogin(AbstractHttpConfigurer::disable) // 기본 로그인 페이지 비활성화
-                .httpBasic(AbstractHttpConfigurer::disable); // HTTP Basic 인증 비활성화
+                // Spring Security 6부터는 인증 정보의 세션 저장 방식이 "자동 저장"에서 "명시적 저장"으로 변경됨
+                .securityContext(context -> context
+                        .requireExplicitSave(false) // 세션 자동 저장 활성화
+                )
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable);
 
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/team6/team6/global/error/exhandler/advice/GlobalExceptionHandler.java
+++ b/src/main/java/com/team6/team6/global/error/exhandler/advice/GlobalExceptionHandler.java
@@ -64,7 +64,7 @@ public class GlobalExceptionHandler {
 
         return ApiResponse.of(
                 HttpStatus.BAD_REQUEST,
-                "잘못된 파라미터",
+                "잘못된 요청",
                 errorMessages
         );
     }

--- a/src/main/java/com/team6/team6/member/controller/MemberController.java
+++ b/src/main/java/com/team6/team6/member/controller/MemberController.java
@@ -1,0 +1,26 @@
+package com.team6.team6.member.controller;
+
+import com.team6.team6.global.ApiResponse;
+import com.team6.team6.member.dto.MemberCreateOrLoginRequest;
+import com.team6.team6.member.dto.MemberResponse;
+import com.team6.team6.member.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/rooms/{roomKey}")
+public class MemberController {
+    private final MemberService memberService;
+
+    @PostMapping("/member")
+    public ApiResponse<MemberResponse> joinOrLogin(
+            @PathVariable String roomKey,
+            @Valid @RequestBody MemberCreateOrLoginRequest request) {
+        MemberResponse response = memberService.joinOrLogin(roomKey, request.toServiceRequest());
+        return ApiResponse.of(HttpStatus.OK,"인증 성공", response);
+    }
+}

--- a/src/main/java/com/team6/team6/member/domain/MemberRepository.java
+++ b/src/main/java/com/team6/team6/member/domain/MemberRepository.java
@@ -1,0 +1,11 @@
+package com.team6.team6.member.domain;
+
+import com.team6.team6.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByNicknameAndRoomId(String nickname, Long roomId);
+    long countByRoomId(Long roomId);
+}

--- a/src/main/java/com/team6/team6/member/dto/MemberCreateOrLoginRequest.java
+++ b/src/main/java/com/team6/team6/member/dto/MemberCreateOrLoginRequest.java
@@ -1,0 +1,30 @@
+package com.team6.team6.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record MemberCreateOrLoginRequest(
+        @NotBlank(message = "닉네임을 입력해주세요")
+        @Pattern(
+            regexp = "^[a-zA-Z0-9가-힣]+$", 
+            message = "닉네임은 특수문자와 이모티콘을 제외한 1글자 이상이어야 합니다"
+        )
+        @Size(min = 1, message = "닉네임은 최소 1글자 이상이어야 합니다")
+        String nickname,
+        
+        @NotBlank(message = "비밀번호를 입력해주세요")
+        @Pattern(
+            regexp = "^(?=.*[a-z])(?=.*[!@#$%^&*(),.?\":{}|<>])(.{6,})$",
+            message = "비밀번호는 영문 소문자, 특수 문자를 포함한 6글자 이상이어야 합니다"
+        )
+        @Size(min = 6, message = "비밀번호는 최소 6글자 이상이어야 합니다")
+        String password
+) {
+    public MemberCreateOrLoginServiceRequest toServiceRequest() {
+        return MemberCreateOrLoginServiceRequest.builder()
+                .nickname(nickname)
+                .password(password)
+                .build();
+    }
+}

--- a/src/main/java/com/team6/team6/member/dto/MemberCreateOrLoginServiceRequest.java
+++ b/src/main/java/com/team6/team6/member/dto/MemberCreateOrLoginServiceRequest.java
@@ -1,0 +1,11 @@
+package com.team6.team6.member.dto;
+
+import lombok.Builder;
+
+public record MemberCreateOrLoginServiceRequest(
+        String nickname,
+        String password
+) {
+    @Builder
+    public MemberCreateOrLoginServiceRequest {}
+}

--- a/src/main/java/com/team6/team6/member/dto/MemberResponse.java
+++ b/src/main/java/com/team6/team6/member/dto/MemberResponse.java
@@ -1,0 +1,21 @@
+package com.team6.team6.member.dto;
+
+import com.team6.team6.member.entity.Member;
+import lombok.Builder;
+
+public record MemberResponse(
+    String nickname,
+    Integer characterId,
+    boolean isLeader
+) {
+    @Builder
+    public MemberResponse {}
+    
+    public static MemberResponse from(Member member) {
+        return new MemberResponse(
+                member.getNickname(),
+                member.getCharacterId(),
+                member.isLeader()
+        );
+    }
+}

--- a/src/main/java/com/team6/team6/member/entity/Member.java
+++ b/src/main/java/com/team6/team6/member/entity/Member.java
@@ -1,0 +1,50 @@
+package com.team6.team6.member.entity;
+
+import com.team6.team6.global.entity.BaseEntity;
+import com.team6.team6.room.entity.Room;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nickname;
+
+    private String password;
+
+    private boolean isLeader;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private Room room;
+
+    private Integer characterId;
+
+    @Builder
+    private Member(String nickname, String password, boolean isLeader, Room room, Integer characterId) {
+        this.nickname = nickname;
+        this.password = password;
+        this.isLeader = isLeader;
+        this.room = room;
+        this.characterId = characterId;
+    }
+
+    public static Member create(String nickname, String password, Room room, Integer characterId, boolean isLeader) {
+        return Member.builder()
+                .nickname(nickname)
+                .password(password)
+                .room(room)
+                .characterId(characterId)
+                .isLeader(isLeader)
+                .build();
+    }
+}

--- a/src/main/java/com/team6/team6/member/security/UserPrincipal.java
+++ b/src/main/java/com/team6/team6/member/security/UserPrincipal.java
@@ -1,0 +1,18 @@
+package com.team6.team6.member.security;
+
+import com.team6.team6.member.entity.Member;
+import lombok.Getter;
+import java.io.Serializable;
+
+@Getter
+public class UserPrincipal implements Serializable {
+    private final Long id;
+    private final String nickname;
+    private final Long roomId;
+
+    public UserPrincipal(Member member) {
+        this.id = member.getId();
+        this.nickname = member.getNickname();
+        this.roomId = member.getRoom().getId();
+    }
+}

--- a/src/main/java/com/team6/team6/member/service/MemberService.java
+++ b/src/main/java/com/team6/team6/member/service/MemberService.java
@@ -1,0 +1,80 @@
+package com.team6.team6.member.service;
+
+import com.team6.team6.member.domain.MemberRepository;
+import com.team6.team6.member.dto.MemberCreateOrLoginServiceRequest;
+import com.team6.team6.member.dto.MemberResponse;
+import com.team6.team6.member.entity.Member;
+import com.team6.team6.member.security.UserPrincipal;
+import com.team6.team6.room.entity.Room;
+import com.team6.team6.room.repository.RoomRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+    private final MemberRepository memberRepository;
+    private final RoomRepository roomRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public MemberResponse joinOrLogin(String roomKey, MemberCreateOrLoginServiceRequest request) {
+        Room room = roomRepository.findByRoomKeyWithLock(roomKey)
+                .orElseThrow(() -> new IllegalArgumentException("방을 찾을 수 없습니다: " + roomKey));
+    
+        return memberRepository.findByNicknameAndRoomId(request.nickname(), room.getId())
+                .map(member -> login(member, request.password()))
+                .orElseGet(() -> join(room, request));
+    }
+
+    private MemberResponse login(Member member, String password) {
+        if (!passwordEncoder.matches(password, member.getPassword())) {
+            throw new BadCredentialsException("비밀번호가 일치하지 않습니다");
+        }
+
+        authenticateUser(member);
+        return MemberResponse.from(member);
+    }
+
+    private MemberResponse join(Room room, MemberCreateOrLoginServiceRequest request) {
+        long currentMemberCount = memberRepository.countByRoomId(room.getId());
+    
+        if (currentMemberCount >= room.getMaxMember()) {
+            throw new IllegalStateException("방의 최대 인원 수에 도달했습니다. 가입할 수 없습니다.");
+        }
+    
+        boolean isFirstMember = currentMemberCount == 0;
+    
+        Member newMember = Member.create(
+                request.nickname(),
+                passwordEncoder.encode(request.password()),
+                room,
+                1,
+                isFirstMember
+        );
+    
+        Member savedMember = memberRepository.save(newMember);
+        authenticateUser(savedMember);
+        return MemberResponse.from(savedMember);
+    }
+
+    private void authenticateUser(Member member) {
+        UserPrincipal userPrincipal = new UserPrincipal(member);
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                userPrincipal,
+                null,
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+
+        // SecurityContext에 인증 객체 저장
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+}

--- a/src/main/java/com/team6/team6/member/service/MemberService.java
+++ b/src/main/java/com/team6/team6/member/service/MemberService.java
@@ -16,7 +16,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -68,10 +69,20 @@ public class MemberService {
 
     private void authenticateUser(Member member) {
         UserPrincipal userPrincipal = new UserPrincipal(member);
+        
+        // 권한 목록 생성
+        List<SimpleGrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
+        
+        // 첫 번째 멤버(리더)인 경우 추가 권한 부여
+        if (member.isLeader()) {
+            authorities.add(new SimpleGrantedAuthority("ROLE_LEADER"));
+        }
+        
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
                 userPrincipal,
                 null,
-                Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"))
+                authorities
         );
 
         // SecurityContext에 인증 객체 저장

--- a/src/main/java/com/team6/team6/room/repository/RoomRepository.java
+++ b/src/main/java/com/team6/team6/room/repository/RoomRepository.java
@@ -1,7 +1,11 @@
 package com.team6.team6.room.repository;
 
 import com.team6.team6.room.entity.Room;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -10,4 +14,8 @@ import java.util.Optional;
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
     Optional<Room> findByRoomKey(String roomKey);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM Room r WHERE r.roomKey = :roomKey")
+    Optional<Room> findByRoomKeyWithLock(@Param("roomKey") String roomKey);
 }

--- a/src/test/java/com/team6/team6/member/controller/MemberControllerDocsTest.java
+++ b/src/test/java/com/team6/team6/member/controller/MemberControllerDocsTest.java
@@ -1,0 +1,122 @@
+package com.team6.team6.member.controller;
+
+import com.team6.team6.global.config.SecurityConfig;
+import com.team6.team6.member.dto.MemberResponse;
+import com.team6.team6.member.service.MemberService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.team6.team6.global.CustomRestDocsHandler.customDocument;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = MemberController.class)
+@AutoConfigureRestDocs
+@Import(SecurityConfig.class)
+class MemberControllerDocsTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MemberService memberService;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+
+    @Test
+    void 회원_가입_또는_로그인_정상_요청_테스트() throws Exception {
+        // given
+        String roomKey = "room123";
+        MemberResponse memberResponse = new MemberResponse("tester", 1, true);
+        
+        given(memberService.joinOrLogin(any(), any())).willReturn(memberResponse);
+
+        // Request body
+        String requestBody = """
+                {
+                    "nickname": "tester",
+                    "password": "test123!"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/rooms/{roomKey}/member", roomKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(customDocument(
+                        "join-or-login",
+                        pathParameters(
+                                parameterWithName("roomKey").description("방 고유 키")
+                        ),
+                        requestFields(
+                                fieldWithPath("nickname").type(JsonFieldType.STRING)
+                                        .description("사용자 닉네임"),
+                                fieldWithPath("password").type(JsonFieldType.STRING)
+                                        .description("사용자 비밀번호")
+                        ),
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                        .description("결과 코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING)
+                                        .description("HTTP 상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("응답 메시지"),
+                                fieldWithPath("data").description("회원 정보"),
+                                fieldWithPath("data.nickname").description("회원 닉네임"),
+                                fieldWithPath("data.characterId").description("캐릭터 ID"),
+                                fieldWithPath("data.isLeader").description("방장 여부")
+                        )
+                ));
+    }
+
+    @Test
+    void 회원_가입_또는_로그인_유효성_검증_실패_테스트() throws Exception {
+        // given
+        String roomKey = "room123";
+
+        // Request body with invalid data
+        String requestBody = """
+                {
+                    "nickname": "",
+                    "password": "123"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(post("/rooms/{roomKey}/member", roomKey)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andDo(customDocument(
+                        "join-or-login-validation-failure",
+                        pathParameters(
+                                parameterWithName("roomKey").description("방 고유 키")
+                        ),
+                        requestFields(
+                                fieldWithPath("nickname").type(JsonFieldType.STRING)
+                                        .description("사용자 닉네임"),
+                                fieldWithPath("password").type(JsonFieldType.STRING)
+                                        .description("사용자 비밀번호")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/team6/team6/member/service/MemberServiceTest.java
+++ b/src/test/java/com/team6/team6/member/service/MemberServiceTest.java
@@ -1,0 +1,449 @@
+package com.team6.team6.member.service;
+
+import com.team6.team6.member.domain.MemberRepository;
+import com.team6.team6.member.dto.MemberCreateOrLoginServiceRequest;
+import com.team6.team6.member.dto.MemberResponse;
+import com.team6.team6.member.entity.Member;
+import com.team6.team6.member.security.UserPrincipal;
+import com.team6.team6.room.dto.RoomCreateServiceRequest;
+import com.team6.team6.room.dto.RoomResponse;
+import com.team6.team6.room.entity.GameMode;
+import com.team6.team6.room.entity.Room;
+import com.team6.team6.room.repository.RoomRepository;
+import com.team6.team6.room.service.RoomService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+    
+    @Autowired
+    private RoomService roomService;
+    
+    @Autowired
+    private RoomRepository roomRepository;
+    
+    @Test
+    void 신규_멤버_가입_성공() {
+        // given
+        RoomCreateServiceRequest roomRequest = new RoomCreateServiceRequest(
+                3, 6, 30, GameMode.NORMAL
+        );
+        RoomResponse roomResponse = roomService.createRoom(roomRequest);
+        String roomKey = roomResponse.roomKey();
+        
+        MemberCreateOrLoginServiceRequest memberRequest = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("테스트유저")
+                .password("test123!")
+                .build();
+                
+        // when
+        MemberResponse response = memberService.joinOrLogin(roomKey, memberRequest);
+        
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response).isNotNull();
+            softly.assertThat(response.nickname()).isEqualTo("테스트유저");
+            softly.assertThat(response.characterId()).isEqualTo(1);
+            softly.assertThat(response.isLeader()).isTrue(); // 첫 번째 멤버는 리더
+            
+            // 실제 DB에 저장되었는지 확인
+            Room room = roomRepository.findByRoomKey(roomKey).orElseThrow();
+            Member member = memberRepository.findByNicknameAndRoomId("테스트유저", room.getId()).orElseThrow();
+            softly.assertThat(member.isLeader()).isTrue();
+            
+            // 인증 상태 확인
+            softly.assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        });
+    }
+    
+    @Test
+    void 기존_멤버_로그인_성공() {
+        // given
+        RoomCreateServiceRequest roomRequest = new RoomCreateServiceRequest(
+                3, 6, 30, GameMode.NORMAL
+        );
+        RoomResponse roomResponse = roomService.createRoom(roomRequest);
+        String roomKey = roomResponse.roomKey();
+        
+        MemberCreateOrLoginServiceRequest memberRequest = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("테스트유저")
+                .password("test123!")
+                .build();
+                
+        // 먼저 회원가입
+        memberService.joinOrLogin(roomKey, memberRequest);
+        
+        
+        // when - 동일한 정보로 로그인
+        MemberResponse response = memberService.joinOrLogin(roomKey, memberRequest);
+        
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response).isNotNull();
+            softly.assertThat(response.nickname()).isEqualTo("테스트유저");
+            softly.assertThat(response.isLeader()).isTrue();
+            
+            // 인증 상태 확인
+            softly.assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        });
+    }
+    
+    @Test
+    void 로그인_비밀번호_불일치시_예외발생() {
+        // given
+        RoomCreateServiceRequest roomRequest = new RoomCreateServiceRequest(
+                3, 6, 30, GameMode.NORMAL
+        );
+        RoomResponse roomResponse = roomService.createRoom(roomRequest);
+        String roomKey = roomResponse.roomKey();
+        
+        // 먼저 회원가입
+        MemberCreateOrLoginServiceRequest joinRequest = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("테스트유저")
+                .password("test123!")
+                .build();
+        memberService.joinOrLogin(roomKey, joinRequest);
+        
+        // 잘못된 비밀번호로 로그인 시도
+        MemberCreateOrLoginServiceRequest loginRequest = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("테스트유저")
+                .password("wrong123!")
+                .build();
+        
+        // when & then
+        assertThatThrownBy(() -> memberService.joinOrLogin(roomKey, loginRequest))
+                .isInstanceOf(BadCredentialsException.class)
+                .hasMessageContaining("비밀번호가 일치하지 않습니다");
+    }
+    
+    @Test
+    void 존재하지_않는_방_멤버_가입시_예외발생() {
+        // given
+        String nonExistentRoomKey = "non-existent-key";
+        
+        MemberCreateOrLoginServiceRequest memberRequest = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("테스트유저")
+                .password("test123!")
+                .build();
+        
+        // when & then
+        assertThatThrownBy(() -> memberService.joinOrLogin(nonExistentRoomKey, memberRequest))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("방을 찾을 수 없습니다");
+    }
+    
+    @Test
+    void 방_최대인원_초과시_가입_실패() {
+        // given
+        RoomCreateServiceRequest roomRequest = new RoomCreateServiceRequest(
+                3, 2, 30, GameMode.NORMAL // 최대 인원 2명으로 설정
+        );
+        RoomResponse roomResponse = roomService.createRoom(roomRequest);
+        String roomKey = roomResponse.roomKey();
+        
+        // 첫 번째 멤버 가입
+        MemberCreateOrLoginServiceRequest member1Request = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("테스트유저1")
+                .password("test123!")
+                .build();
+        memberService.joinOrLogin(roomKey, member1Request);
+        
+        // 두 번째 멤버 가입
+        MemberCreateOrLoginServiceRequest member2Request = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("테스트유저2")
+                .password("test123!")
+                .build();
+        memberService.joinOrLogin(roomKey, member2Request);
+        
+        // 세 번째 멤버 가입 시도 (최대 인원 초과)
+        MemberCreateOrLoginServiceRequest member3Request = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("테스트유저3")
+                .password("test123!")
+                .build();
+        
+        // when & then
+        assertThatThrownBy(() -> memberService.joinOrLogin(roomKey, member3Request))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("방의 최대 인원 수에 도달했습니다");
+    }
+    
+    @Test
+    void 두번째_이후_멤버는_리더가_아님() {
+        // given
+        RoomCreateServiceRequest roomRequest = new RoomCreateServiceRequest(
+                3, 3, 30, GameMode.NORMAL
+        );
+        RoomResponse roomResponse = roomService.createRoom(roomRequest);
+        String roomKey = roomResponse.roomKey();
+        
+        // 첫 번째 멤버 가입
+        MemberCreateOrLoginServiceRequest member1Request = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("테스트유저1")
+                .password("test123!")
+                .build();
+        MemberResponse response1 = memberService.joinOrLogin(roomKey, member1Request);
+        
+        // 두 번째 멤버 가입
+        MemberCreateOrLoginServiceRequest member2Request = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("테스트유저2")
+                .password("test123!")
+                .build();
+        
+        // when
+        MemberResponse response2 = memberService.joinOrLogin(roomKey, member2Request);
+        
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response1.isLeader()).isTrue(); // 첫 번째 멤버는 리더
+            softly.assertThat(response2.isLeader()).isFalse(); // 두 번째 멤버는 리더가 아님
+        });
+    }
+    
+    @Test
+    void 닉네임_중복_확인() {
+        // given
+        RoomCreateServiceRequest roomRequest = new RoomCreateServiceRequest(
+                3, 6, 30, GameMode.NORMAL
+        );
+        RoomResponse roomResponse = roomService.createRoom(roomRequest);
+        String roomKey = roomResponse.roomKey();
+        
+        // 첫 번째 멤버 가입
+        MemberCreateOrLoginServiceRequest memberRequest = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("중복닉네임")
+                .password("test123!")
+                .build();
+        
+        memberService.joinOrLogin(roomKey, memberRequest);
+        
+        
+        // 다른 비밀번호로 동일 닉네임 가입시도
+        MemberCreateOrLoginServiceRequest duplicateRequest = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("중복닉네임")
+                .password("different!")
+                .build();
+        
+        // when & then
+        assertThatThrownBy(() -> memberService.joinOrLogin(roomKey, duplicateRequest))
+                .isInstanceOf(BadCredentialsException.class)
+                .hasMessageContaining("비밀번호가 일치하지 않습니다");
+    }
+    
+    @Test
+    void 인증_컨텍스트_검증() {
+        // given
+        RoomCreateServiceRequest roomRequest = new RoomCreateServiceRequest(
+                3, 6, 30, GameMode.NORMAL
+        );
+        RoomResponse roomResponse = roomService.createRoom(roomRequest);
+        String roomKey = roomResponse.roomKey();
+        
+        MemberCreateOrLoginServiceRequest memberRequest = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("테스트유저")
+                .password("test123!")
+                .build();
+                
+        // when
+        memberService.joinOrLogin(roomKey, memberRequest);
+        
+        // then
+        assertSoftly(softly -> {
+            // 인증 객체가 존재하는지 확인
+            var authentication = SecurityContextHolder.getContext().getAuthentication();
+            softly.assertThat(authentication).isNotNull();
+            
+            // Principal이 올바른 타입인지 확인
+            softly.assertThat(authentication.getPrincipal()).isInstanceOf(UserPrincipal.class);
+            
+            // UserPrincipal에 올바른 정보가 들어있는지 확인
+            var principal = (UserPrincipal) authentication.getPrincipal();
+            softly.assertThat(principal.getNickname()).isEqualTo("테스트유저");
+            
+            // 권한(Authorities) 확인 - 첫 번째 멤버는 ROLE_USER와 ROLE_LEADER 모두 가짐
+            softly.assertThat(authentication.getAuthorities()).hasSize(2);
+            
+            // 권한 목록에 ROLE_USER와 ROLE_LEADER가 모두 포함되어 있는지 확인
+            var authorities = authentication.getAuthorities().stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .collect(Collectors.toList());
+            softly.assertThat(authorities).contains("ROLE_USER", "ROLE_LEADER");
+        });
+    }
+    
+    @Test
+    void 로그인_시_보안_컨텍스트_갱신() {
+        // given
+        RoomCreateServiceRequest roomRequest = new RoomCreateServiceRequest(
+                3, 6, 30, GameMode.NORMAL
+        );
+        RoomResponse roomResponse = roomService.createRoom(roomRequest);
+        String roomKey = roomResponse.roomKey();
+        
+        // 첫 번째 멤버 가입
+        MemberCreateOrLoginServiceRequest member1Request = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("유저1")
+                .password("test123!")
+                .build();
+        memberService.joinOrLogin(roomKey, member1Request);
+        
+        // 명시적으로 SecurityContext 초기화
+        SecurityContextHolder.clearContext();
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        
+        // 두 번째 멤버 가입
+        MemberCreateOrLoginServiceRequest member2Request = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("유저2")
+                .password("test123!")
+                .build();
+        
+        // when
+        memberService.joinOrLogin(roomKey, member2Request);
+        
+        // then
+        assertSoftly(softly -> {
+            var authentication = SecurityContextHolder.getContext().getAuthentication();
+            softly.assertThat(authentication).isNotNull();
+            
+            var principal = (UserPrincipal) authentication.getPrincipal();
+            softly.assertThat(principal.getNickname()).isEqualTo("유저2");
+            
+            // 이전 사용자가 아닌 현재 사용자 정보가 들어있는지 확인
+            softly.assertThat(principal.getNickname()).isNotEqualTo("유저1");
+        });
+    }
+    
+    @Test
+    void 보안_컨텍스트_초기화_후_로그인() {
+        // given
+        RoomCreateServiceRequest roomRequest = new RoomCreateServiceRequest(
+                3, 6, 30, GameMode.NORMAL
+        );
+        RoomResponse roomResponse = roomService.createRoom(roomRequest);
+        String roomKey = roomResponse.roomKey();
+        
+        MemberCreateOrLoginServiceRequest memberRequest = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("테스트유저")
+                .password("test123!")
+                .build();
+        
+        // 첫 번째 로그인
+        memberService.joinOrLogin(roomKey, memberRequest);
+        
+        // 명시적 컨텍스트 초기화
+        SecurityContextHolder.clearContext();
+        
+        // when - 두 번째 로그인
+        memberService.joinOrLogin(roomKey, memberRequest);
+        
+        // then
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertSoftly(softly -> {
+            softly.assertThat(authentication).isNotNull();
+            softly.assertThat(authentication.getPrincipal()).isInstanceOf(UserPrincipal.class);
+            
+            var principal = (UserPrincipal) authentication.getPrincipal();
+            softly.assertThat(principal.getNickname()).isEqualTo("테스트유저");
+        });
+    }
+    
+    @Test
+    void 첫번째_멤버는_리더_권한_가짐() {
+        // given
+        RoomCreateServiceRequest roomRequest = new RoomCreateServiceRequest(
+                3, 6, 30, GameMode.NORMAL
+        );
+        RoomResponse roomResponse = roomService.createRoom(roomRequest);
+        String roomKey = roomResponse.roomKey();
+        
+        MemberCreateOrLoginServiceRequest leaderRequest = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("방장")
+                .password("test123!")
+                .build();
+                
+        // when
+        memberService.joinOrLogin(roomKey, leaderRequest);
+        
+        // then
+        assertSoftly(softly -> {
+            // 인증 객체가 존재하는지 확인
+            var authentication = SecurityContextHolder.getContext().getAuthentication();
+            softly.assertThat(authentication).isNotNull();
+            
+            // 권한(Authorities) 확인 - 리더는 ROLE_USER와 ROLE_LEADER 두 권한을 가짐
+            softly.assertThat(authentication.getAuthorities()).hasSize(2);
+            
+            // 권한 목록에 ROLE_USER와 ROLE_LEADER가 모두 포함되어 있는지 확인
+            var authorities = authentication.getAuthorities().stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .collect(Collectors.toList());
+            softly.assertThat(authorities).contains("ROLE_USER", "ROLE_LEADER");
+        });
+    }
+    
+    @Test
+    void 두번째_멤버는_일반_권한만_가짐() {
+        // given
+        RoomCreateServiceRequest roomRequest = new RoomCreateServiceRequest(
+                3, 6, 30, GameMode.NORMAL
+        );
+        RoomResponse roomResponse = roomService.createRoom(roomRequest);
+        String roomKey = roomResponse.roomKey();
+        
+        // 첫 번째 멤버 가입(리더)
+        MemberCreateOrLoginServiceRequest leaderRequest = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("방장")
+                .password("test123!")
+                .build();
+        memberService.joinOrLogin(roomKey, leaderRequest);
+        
+        // SecurityContext 초기화
+        SecurityContextHolder.clearContext();
+        
+        // 두 번째 멤버 가입(일반 멤버)
+        MemberCreateOrLoginServiceRequest memberRequest = MemberCreateOrLoginServiceRequest.builder()
+                .nickname("일반멤버")
+                .password("test123!")
+                .build();
+        
+        // when
+        memberService.joinOrLogin(roomKey, memberRequest);
+        
+        // then
+        assertSoftly(softly -> {
+            // 인증 객체가 존재하는지 확인
+            var authentication = SecurityContextHolder.getContext().getAuthentication();
+            softly.assertThat(authentication).isNotNull();
+            
+            // 권한(Authorities) 확인 - 일반 멤버는 ROLE_USER 권한만 가짐
+            softly.assertThat(authentication.getAuthorities()).hasSize(1);
+            
+            // 권한 목록에 ROLE_USER만 포함되어 있는지 확인
+            var authorities = authentication.getAuthorities().stream()
+                    .map(GrantedAuthority::getAuthority)
+                    .collect(Collectors.toList());
+            softly.assertThat(authorities).contains("ROLE_USER");
+            softly.assertThat(authorities).doesNotContain("ROLE_LEADER");
+        });
+    }
+}


### PR DESCRIPTION
## 회원 관련 작업 진행
- [X] 회원 컨트롤러 구현
- [X] 회원 서비스 구현
- [X] 회원 도메인 구현
- [X] 회원 관련 테스트 코드 작성
- [X] 회원 관련 restdocs 작성
- [X] 회원 인증 및 보안 설정 구현


<br>

## 🔨 작업 사항

### 회원 생성 및 로그인 로직
- 닉네임으로 새 사용자 생성 또는 기존 사용자 로그인 기능 구현

```java
@RestController
@RequiredArgsConstructor
@RequestMapping("/rooms/{roomKey}")
public class MemberController {
    private final MemberService memberService;

    @PostMapping("/member")
    public ApiResponse<MemberResponse> joinOrLogin(
            @PathVariable String roomKey,
            @Valid @RequestBody MemberCreateOrLoginRequest request) {
        MemberResponse response = memberService.joinOrLogin(roomKey, request.toServiceRequest());
        return ApiResponse.of(HttpStatus.OK,"인증 성공", response);
    }
}
```

- 기존 회원이 없으면 회원가입, 있으면 로그인 처리
- 방의 첫 회원이 방장으로 설정
- 로그인 후 securityContextHolder에 회원 정보 저장
- PasswordEncoder를 사용하여 비밀번호 암호화 하여 저장

```java
@Service
@RequiredArgsConstructor
public class MemberService {
    private final MemberRepository memberRepository;
    private final RoomRepository roomRepository;
    private final PasswordEncoder passwordEncoder;

    @Transactional
    public MemberResponse joinOrLogin(String roomKey, MemberCreateOrLoginServiceRequest request) {
        Room room = roomRepository.findByRoomKeyWithLock(roomKey)
                .orElseThrow(() -> new IllegalArgumentException("방을 찾을 수 없습니다: " + roomKey));
    
        return memberRepository.findByNicknameAndRoomId(request.nickname(), room.getId())
                .map(member -> login(member, request.password()))
                .orElseGet(() -> join(room, request));
    }

    private MemberResponse login(Member member, String password) {
        if (!passwordEncoder.matches(password, member.getPassword())) {
            throw new BadCredentialsException("비밀번호가 일치하지 않습니다");
        }

        authenticateUser(member);
        return MemberResponse.from(member);
    }

    private MemberResponse join(Room room, MemberCreateOrLoginServiceRequest request) {
        long currentMemberCount = memberRepository.countByRoomId(room.getId());
    
        if (currentMemberCount >= room.getMaxMember()) {
            throw new IllegalStateException("방의 최대 인원 수에 도달했습니다. 가입할 수 없습니다.");
        }
    
        boolean isFirstMember = currentMemberCount == 0;
    
        Member newMember = Member.create(
                request.nickname(),
                passwordEncoder.encode(request.password()),
                room,
                1,
                isFirstMember
        );
    
        Member savedMember = memberRepository.save(newMember);
        authenticateUser(savedMember);
        return MemberResponse.from(savedMember);
    }

    private void authenticateUser(Member member) {
        UserPrincipal userPrincipal = new UserPrincipal(member);
        
        // 권한 목록 생성
        List<SimpleGrantedAuthority> authorities = new ArrayList<>();
        authorities.add(new SimpleGrantedAuthority("ROLE_USER"));
        
        // 첫 번째 멤버(리더)인 경우 추가 권한 부여
        if (member.isLeader()) {
            authorities.add(new SimpleGrantedAuthority("ROLE_LEADER"));
        }
        
        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
                userPrincipal,
                null,
                authorities
        );

        // SecurityContext에 인증 객체 저장
        SecurityContextHolder.getContext().setAuthentication(auth);
    }
}
```
- 동시성 문제는 `@Lock(LockModeType.PESSIMISTIC_WRITE)`를 사용하여 해결
```java
@Repository
public interface RoomRepository extends JpaRepository<Room, Long> {

    Optional<Room> findByRoomKey(String roomKey);

    @Lock(LockModeType.PESSIMISTIC_WRITE)
    @Query("SELECT r FROM Room r WHERE r.roomKey = :roomKey")
    Optional<Room> findByRoomKeyWithLock(@Param("roomKey") String roomKey);
}
```
### spring-security 설정
- spring-security 설정을 통해 인증 및 권한 부여 처리
- Spring Security 6부터는 인증 정보의 세션 저장 방식이 "자동 저장"에서 "명시적 저장"으로 변경됨
  - `securityContext.requireExplicitSave(false)`를 사용하여 세션 자동 저장 활성화를 해줘야함
  - https://docs.spring.io/spring-security/reference/servlet/authentication/session-management.html
```java
@Configuration
@EnableWebSecurity
public class SecurityConfig {

    @Bean
    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
        http
                .csrf(AbstractHttpConfigurer::disable)
                .authorizeHttpRequests(auth -> auth
                        .requestMatchers("/rooms/*/member").permitAll() // 회원가입/로그인은 허용
                        .requestMatchers(HttpMethod.POST, "/rooms").permitAll() // 방 생성은 허용
                        .requestMatchers(HttpMethod.GET, "/rooms/*").authenticated() // 방 조회는 인증 필요
                        .requestMatchers(HttpMethod.PATCH, "/rooms/*/close").authenticated() // 방 종료는 인증 필요
                        .anyRequest().authenticated()
                )
                // Spring Security 6부터는 인증 정보의 세션 저장 방식이 "자동 저장"에서 "명시적 저장"으로 변경됨
                .securityContext(context -> context
                        .requireExplicitSave(false) // 세션 자동 저장 활성화
                )
                .formLogin(AbstractHttpConfigurer::disable)
                .httpBasic(AbstractHttpConfigurer::disable);

        return http.build();
    }

    @Bean
    public PasswordEncoder passwordEncoder() {
        return new BCryptPasswordEncoder();
    }
}

```


