### PR TITLE
테스트 수정 및 모니터링 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,27 +31,40 @@ ext {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-websocket'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
-	testImplementation 'org.springframework.security:spring-security-test'
-	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-	// H2 데이터베이스 의존성 추가
-	runtimeOnly 'com.h2database:h2'
-	// spring validation 의존성 추가
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	// 스프링 재시도 로직 의존성 추가
-	implementation 'org.springframework.retry:spring-retry'
-	implementation 'org.springframework.boot:spring-boot-starter-aop'
-  // Spring AI
-  implementation 'org.springframework.ai:spring-ai-starter-model-openai:1.0.0-M7'
+    // == Web & Validation ==
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    // == Security ==
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // == JPA & DB ==
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    runtimeOnly 'com.h2database:h2'
+
+    // == Monitoring ==
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // == AI Integration ==
+    implementation 'org.springframework.ai:spring-ai-starter-model-openai:1.0.0-M7'
+
+    // == REST Docs ==
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+
+    // == Testing ==
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // == Lombok ==
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/test/java/com/team6/team6/keyword/service/KeywordServiceAsyncTest.java
+++ b/src/test/java/com/team6/team6/keyword/service/KeywordServiceAsyncTest.java
@@ -12,7 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
@@ -22,10 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 @SpringBootTest
-@TestPropertySource(properties = {
-        "spring.task.execution.pool.core-size=4",
-        "spring.task.execution.pool.max-size=8"
-})
+@ActiveProfiles("test")
 class KeywordServiceAsyncTest {
 
     @TestConfiguration

--- a/src/test/java/com/team6/team6/keyword/service/KeywordServiceNonAsyncTest.java
+++ b/src/test/java/com/team6/team6/keyword/service/KeywordServiceNonAsyncTest.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
@@ -21,10 +21,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 @SpringBootTest
-@TestPropertySource(properties = {
-        "spring.task.execution.pool.core-size=4",
-        "spring.task.execution.pool.max-size=8"
-})
+@ActiveProfiles("test")
 class KeywordServiceNonAsyncTest {
 
     @TestConfiguration

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,4 +1,9 @@
 spring:
+  task:
+    execution:
+      pool:
+        core-size: 4
+        max-size: 8
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MySQL;
     username: sa


### PR DESCRIPTION
## 🔨 작업 사항 
### 테스트 관련 수정
```
spring:
  task:
    execution:
      pool:
        core-size: 4
        max-size: 8
  datasource:
    url: jdbc:h2:mem:testdb;MODE=MySQL;
    username: sa
    password:
    driver-class-name: org.h2.Driver
  jpa:
    hibernate:
      ddl-auto: create-drop
    properties:
      hibernate:
        dialect: org.hibernate.dialect.MySQL8Dialect
        format_sql: true
    show-sql: true
```
- pool size 설정 파일로 분리
- yml 파일 위치 `src/test/resources`로 이동
- `SpringBootTest`에 `@ActiveProfiles` 추가

