### PR TITLE
dev 환경 모니터링 CI/CD

### DIFF
--- a/.github/workflows/monitoring_dev.yml
+++ b/.github/workflows/monitoring_dev.yml
@@ -1,0 +1,22 @@
+name: Monitoring Dev CI/CD
+
+on:
+  push:
+    branches:
+      - monitoring_dev
+
+jobs:
+  deploy-monitoring-dev:
+    runs-on: macmini
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy DEV monitoring stack
+        working-directory: monitoring
+        env:
+          GRAFANA_USER: ${{ secrets.GRAFANA_USER }}
+          GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
+        run: |
+          docker compose -f docker-compose.base.yml -f docker-compose.dev.yml down
+          docker compose -f docker-compose.base.yml -f docker-compose.dev.yml up -d

--- a/monitoring/docker-compose.base.yml
+++ b/monitoring/docker-compose.base.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_USER}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD}
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    restart: unless-stopped

--- a/monitoring/docker-compose.dev.yml
+++ b/monitoring/docker-compose.dev.yml
@@ -1,0 +1,15 @@
+services:
+  grafana:
+    ports:
+      - "3001:3000"
+    volumes:
+      - grafana-storage-dev:/var/lib/grafana
+
+  prometheus:
+    ports:
+      - "9091:9090"
+    volumes:
+      - ./prometheus/prometheus_dev.yml:/etc/prometheus/prometheus.yml
+
+volumes:
+  grafana-storage-dev:

--- a/monitoring/prometheus/prometheus_dev.yml
+++ b/monitoring/prometheus/prometheus_dev.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    scrape_interval: 30s
+    static_configs:
+      - targets: [ 'host.docker.internal:9091' ]
+
+  - job_name: 'spring-boot-app'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: [ 'host.docker.internal:8081' ]


### PR DESCRIPTION
## 🔨 작업 사항 

### Monitoring 시스템용 GitHub Actions CI/CD 구축
- `monitoring-dev` 브랜치에 push 시 자동으로 Prometheus + Grafana dev 환경을 배포하는 워크플로우 추가
- 워크플로우 경로: `.github/workflows/monitoring_dev.yml`
- 환경 변수(GRAFANA_USER, GRAFANA_PASSWORD)는 GitHub Secrets를 통해 주입
```yaml
docker compose -f docker-compose.base.yml -f docker-compose.dev.yml down
docker compose -f docker-compose.base.yml -f docker-compose.dev.yml up -d
```

### 환경별 Docker Compose 파일 구성
**docker-compose.base.yml**
```yaml
version: '3.8'

services:
  grafana:
    image: grafana/grafana:latest
    container_name: grafana
    environment:
      GF_SECURITY_ADMIN_USER: ${GRAFANA_USER}
      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD}
    restart: unless-stopped

  prometheus:
    image: prom/prometheus:latest
    container_name: prometheus
    restart: unless-stopped
```
- 공통 서비스 정의 (이미지, 컨테이너 이름, 인증 변수)

**docker-compose.dev.yml**
```yaml
services:
  grafana:
    ports:
      - "3001:3000"
    volumes:
      - grafana-storage-dev:/var/lib/grafana

  prometheus:
    ports:
      - "9091:9090"
    volumes:
      - ./prometheus/prometheus_dev.yml:/etc/prometheus/prometheus.yml

volumes:
  grafana-storage-dev:
```
- dev 전용 포트, 볼륨, 프로메테우스 설정 파일 마운트

### Prometheus 설정 파일 작성
- dev 환경용 scrape 설정 추가
- Prometheus 자체와 Spring Boot 애플리케이션의 /actuator/prometheus endpoint 모니터링

### 참고
- Grafana 포트: 3001
- Prometheus 포트: 9091
- Grafana 데이터는 환경별로 분리된 볼륨(grafana-storage-dev)에 저장되도록 구성
