### PR TITLE
분석 결과 저장소 활용

### DIFF
--- a/src/main/java/com/team6/team6/keyword/domain/AnalysisResultStore.java
+++ b/src/main/java/com/team6/team6/keyword/domain/AnalysisResultStore.java
@@ -9,7 +9,7 @@ public interface AnalysisResultStore {
 
     List<AnalysisResult> findByRoomId(Long roomId);
 
-    List<String> findSharedKeywordsByRoomId(Long roomId);
+    List<String> findSharedKeywordsByRoomId(Long roomId, Integer requiredAgreements);
 
-    List<String> findReferenceNamesByRoomId(Long roomId);
+    List<String> findReferenceNamesByRoomId(Long roomId, Integer requiredAgreements);
 }

--- a/src/main/java/com/team6/team6/keyword/domain/AnalysisResultStore.java
+++ b/src/main/java/com/team6/team6/keyword/domain/AnalysisResultStore.java
@@ -10,4 +10,6 @@ public interface AnalysisResultStore {
     List<AnalysisResult> findByRoomId(Long roomId);
 
     List<String> findSharedKeywordsByRoomId(Long roomId);
+
+    List<String> findReferenceNamesByRoomId(Long roomId);
 }

--- a/src/main/java/com/team6/team6/keyword/domain/AnalysisResultStore.java
+++ b/src/main/java/com/team6/team6/keyword/domain/AnalysisResultStore.java
@@ -1,0 +1,13 @@
+package com.team6.team6.keyword.domain;
+
+import com.team6.team6.keyword.dto.AnalysisResult;
+
+import java.util.List;
+
+public interface AnalysisResultStore {
+    void save(Long roomId, List<AnalysisResult> analysisResults);
+
+    List<AnalysisResult> findByRoomId(Long roomId);
+
+    List<String> findSharedKeywordsByRoomId(Long roomId);
+}

--- a/src/main/java/com/team6/team6/keyword/infrastructure/InMemoryAnalysisResultStore.java
+++ b/src/main/java/com/team6/team6/keyword/infrastructure/InMemoryAnalysisResultStore.java
@@ -1,0 +1,42 @@
+package com.team6.team6.keyword.infrastructure;
+
+import com.team6.team6.keyword.domain.AnalysisResultStore;
+import com.team6.team6.keyword.dto.AnalysisResult;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Component
+public class InMemoryAnalysisResultStore implements AnalysisResultStore {
+
+    // 방 ID를 키로 하고, 해당 방의 분석 결과 리스트를 값으로 하는 맵
+    private final Map<Long, List<AnalysisResult>> resultStore = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(Long roomId, List<AnalysisResult> analysisResults) {
+        // 기존 결과를 새 결과로 교체
+        resultStore.put(roomId, new ArrayList<>(analysisResults));
+    }
+
+    @Override
+    public List<AnalysisResult> findByRoomId(Long roomId) {
+        // 해당 방의 모든 분석 결과 조회
+        return resultStore.getOrDefault(roomId, new ArrayList<>());
+    }
+
+    @Override
+    public List<String> findSharedKeywordsByRoomId(Long roomId) {
+        // 해당 방의 모든 분석 결과에서 중복 없이 키워드 이름만 추출
+        List<AnalysisResult> results = findByRoomId(roomId);
+
+        // 모든 분석 결과에서 variations에 있는 모든 값을 하나의 리스트로 모으고 중복 제거
+        return results.stream()
+                .flatMap(result -> result.variations().stream())
+                .distinct()
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/team6/team6/keyword/infrastructure/InMemoryAnalysisResultStore.java
+++ b/src/main/java/com/team6/team6/keyword/infrastructure/InMemoryAnalysisResultStore.java
@@ -39,4 +39,16 @@ public class InMemoryAnalysisResultStore implements AnalysisResultStore {
                 .distinct()
                 .collect(Collectors.toList());
     }
+
+    @Override
+    public List<String> findReferenceNamesByRoomId(Long roomId) {
+        // 해당 방의 모든 분석 결과에서 중복 없이 참조 이름만 추출
+        List<AnalysisResult> results = findByRoomId(roomId);
+
+        // 모든 분석 결과에서 referenceName에 있는 모든 값을 하나의 리스트로 모으고 중복 제거
+        return results.stream()
+                .map(AnalysisResult::referenceName)
+                .distinct()
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/team6/team6/keyword/infrastructure/InMemoryAnalysisResultStore.java
+++ b/src/main/java/com/team6/team6/keyword/infrastructure/InMemoryAnalysisResultStore.java
@@ -29,24 +29,22 @@ public class InMemoryAnalysisResultStore implements AnalysisResultStore {
     }
 
     @Override
-    public List<String> findSharedKeywordsByRoomId(Long roomId) {
-        // 해당 방의 모든 분석 결과에서 중복 없이 키워드 이름만 추출
+    public List<String> findSharedKeywordsByRoomId(Long roomId, Integer requiredAgreements) {
         List<AnalysisResult> results = findByRoomId(roomId);
 
-        // 모든 분석 결과에서 variations에 있는 모든 값을 하나의 리스트로 모으고 중복 제거
         return results.stream()
+                .filter(result -> result.count() >= requiredAgreements)
                 .flatMap(result -> result.variations().stream())
                 .distinct()
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<String> findReferenceNamesByRoomId(Long roomId) {
-        // 해당 방의 모든 분석 결과에서 중복 없이 참조 이름만 추출
+    public List<String> findReferenceNamesByRoomId(Long roomId, Integer requiredAgreements) {
         List<AnalysisResult> results = findByRoomId(roomId);
 
-        // 모든 분석 결과에서 referenceName에 있는 모든 값을 하나의 리스트로 모으고 중복 제거
         return results.stream()
+                .filter(result -> result.count() >= requiredAgreements)
                 .map(AnalysisResult::referenceName)
                 .distinct()
                 .collect(Collectors.toList());

--- a/src/test/java/com/team6/team6/keyword/infrastructure/InMemoryAnalysisResultStoreTest.java
+++ b/src/test/java/com/team6/team6/keyword/infrastructure/InMemoryAnalysisResultStoreTest.java
@@ -106,6 +106,28 @@ class InMemoryAnalysisResultStoreTest {
     }
 
     @Test
+    void 공감된_키워드들을_중복_없이_가져올_수_있다() {
+        // given
+        Long roomId = 1L;
+        AnalysisResult result1 = AnalysisResult.of("자바", Arrays.asList("Java", "JAVA", "자바"));
+        AnalysisResult result2 = AnalysisResult.of("파이썬", Arrays.asList("Python", "python", "파이썬"));
+        AnalysisResult result3 = AnalysisResult.of("자바스크립트", Arrays.asList("JavaScript", "JS"));
+
+        store.save(roomId, Arrays.asList(result1, result2, result3));
+
+        // when
+        List<String> sharedKeywords = store.findReferenceNamesByRoomId(roomId);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(sharedKeywords).hasSize(3);
+            softly.assertThat(sharedKeywords).containsExactlyInAnyOrder(
+                    "자바", "파이썬", "자바스크립트"
+            );
+        });
+    }
+
+    @Test
     void 서로_다른_방_ID의_결과는_독립적으로_관리된다() {
         // given
         Long roomId1 = 1L;

--- a/src/test/java/com/team6/team6/keyword/infrastructure/InMemoryAnalysisResultStoreTest.java
+++ b/src/test/java/com/team6/team6/keyword/infrastructure/InMemoryAnalysisResultStoreTest.java
@@ -1,0 +1,133 @@
+package com.team6.team6.keyword.infrastructure;
+
+import com.team6.team6.keyword.dto.AnalysisResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+class InMemoryAnalysisResultStoreTest {
+
+    private InMemoryAnalysisResultStore store;
+
+    @BeforeEach
+    void setUp() {
+        store = new InMemoryAnalysisResultStore();
+    }
+
+    @Test
+    void 분석_결과를_저장하고_조회할_수_있다() {
+        // given
+        Long roomId = 1L;
+        AnalysisResult result = AnalysisResult.of("자바", Arrays.asList("Java", "JAVA", "자바"));
+
+        // when
+        store.save(roomId, List.of(result));
+        List<AnalysisResult> savedResults = store.findByRoomId(roomId);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(savedResults).hasSize(1);
+            softly.assertThat(savedResults.get(0).referenceName()).isEqualTo("자바");
+            softly.assertThat(savedResults.get(0).variations()).containsExactly("Java", "JAVA", "자바");
+        });
+    }
+
+    @Test
+    void 존재하지_않는_방_ID로_조회하면_빈_리스트가_반환된다() {
+        // given
+        Long nonExistentRoomId = 999L;
+
+        // when
+        List<AnalysisResult> results = store.findByRoomId(nonExistentRoomId);
+
+        // then
+        assertThat(results).isEmpty();
+    }
+
+    @Test
+    void 기존_결과가_있을_때_저장하면_교체된다() {
+        // given
+        Long roomId = 1L;
+        AnalysisResult firstResult = AnalysisResult.of("파이썬", Arrays.asList("파이썬"));
+        store.save(roomId, List.of(firstResult));
+
+        // when
+        AnalysisResult secondResult = AnalysisResult.of("파이썬", Arrays.asList("파이썬", "Python"));
+        store.save(roomId, List.of(secondResult));
+
+        // then
+        List<AnalysisResult> results = store.findByRoomId(roomId);
+        assertSoftly(softly -> {
+            softly.assertThat(results).hasSize(1);
+            softly.assertThat(results.get(0).referenceName()).isEqualTo("파이썬");
+            softly.assertThat(results.get(0).variations()).containsExactly("파이썬", "Python");
+        });
+    }
+
+    @Test
+    void 여러_분석_결과를_저장할_수_있다() {
+        // given
+        Long roomId = 1L;
+        AnalysisResult result1 = AnalysisResult.of("자바", Arrays.asList("Java", "JAVA", "자바"));
+        AnalysisResult result2 = AnalysisResult.of("파이썬", Arrays.asList("Python", "파이썬"));
+        // when
+        store.save(roomId, Arrays.asList(result1, result2));
+
+        // then
+        List<AnalysisResult> results = store.findByRoomId(roomId);
+        assertThat(results).hasSize(2);
+    }
+
+    @Test
+    void 공유_키워드_목록을_중복_없이_가져올_수_있다() {
+        // given
+        Long roomId = 1L;
+        AnalysisResult result1 = AnalysisResult.of("자바", Arrays.asList("Java", "JAVA", "자바"));
+        AnalysisResult result2 = AnalysisResult.of("파이썬", Arrays.asList("Python", "python", "파이썬"));
+        AnalysisResult result3 = AnalysisResult.of("자바스크립트", Arrays.asList("JavaScript", "JS"));
+
+        store.save(roomId, Arrays.asList(result1, result2, result3));
+
+        // when
+        List<String> sharedKeywords = store.findSharedKeywordsByRoomId(roomId);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(sharedKeywords).hasSize(8);
+            softly.assertThat(sharedKeywords).containsExactlyInAnyOrder(
+                    "Java", "JAVA", "자바", "Python", "python", "파이썬", "JavaScript", "JS"
+            );
+        });
+    }
+
+    @Test
+    void 서로_다른_방_ID의_결과는_독립적으로_관리된다() {
+        // given
+        Long roomId1 = 1L;
+        Long roomId2 = 2L;
+
+        AnalysisResult result1 = AnalysisResult.of("자바", Arrays.asList("Java", "자바"));
+        AnalysisResult result2 = AnalysisResult.of("파이썬", Arrays.asList("Python", "파이썬"));
+
+        // when
+        store.save(roomId1, List.of(result1));
+        store.save(roomId2, List.of(result2));
+
+        // then
+        List<AnalysisResult> results1 = store.findByRoomId(roomId1);
+        List<AnalysisResult> results2 = store.findByRoomId(roomId2);
+
+        assertSoftly(softly -> {
+            softly.assertThat(results1).hasSize(1);
+            softly.assertThat(results1.get(0).referenceName()).isEqualTo("자바");
+
+            softly.assertThat(results2).hasSize(1);
+            softly.assertThat(results2.get(0).referenceName()).isEqualTo("파이썬");
+        });
+    }
+}


### PR DESCRIPTION
## 🔨 작업 사항 
### 키워드 매니저가 분석 결과 저장소 활용
`문제 상황`
- 사용자 입장 시 키워드 분석 결과를 반환해야 함
- 키워드 추가 없이 분석기(gpt)를 이용해 다시 그룹화 하는 중복 작업 발생

`해결 방법`
- 분석 결과 저장소를 활용해 중복 작업을 없앰

```java
public List<AnalysisResult> analyzeKeywords(Long roomId) {
        // 먼저 analysisResultStore에서 결과가 있는지 확인
        List<AnalysisResult> storedResults = analysisResultStore.findByRoomId(roomId);
        // 저장된 결과가 있으면 그대로 반환
        if (!storedResults.isEmpty()) {
            return storedResults;
        }
        // 저장된 결과가 없으면 새로 분석
        return analyzeAndSave(roomId);
    }

private List<AnalysisResult> analyzeAndSave(Long roomId) {
        List<String> keywordsInStore = keywordStore.getKeywords(roomId);
        List<List<String>> groupedResult = keywordSimilarityAnalyser.analyse(keywordsInStore);

        return convertToAnalysisResult(groupedResult, keywordsInStore);
        List<AnalysisResult> results = convertToAnalysisResult(groupedResult, keywordsInStore);
        // 분석 결과 저장
        analysisResultStore.save(roomId, results);
        return results;
    }
```
- 먼저 분석 결과 저장소를 먼저 조회해서 마지막 분석 결과를 반환

