### PR TITLE
멤버 characterId -> 캐릭터명 enum으로 수정

### DIFF
--- a/src/main/java/com/team6/team6/member/dto/MemberResponse.java
+++ b/src/main/java/com/team6/team6/member/dto/MemberResponse.java
@@ -1,20 +1,21 @@
 package com.team6.team6.member.dto;
 
+import com.team6.team6.member.entity.CharacterType;
 import com.team6.team6.member.entity.Member;
 import lombok.Builder;
 
 public record MemberResponse(
-    String nickname,
-    Integer characterId,
-    boolean isLeader
+        String nickname,
+        CharacterType character,
+        boolean isLeader
 ) {
     @Builder
     public MemberResponse {}
-    
+
     public static MemberResponse from(Member member) {
         return new MemberResponse(
                 member.getNickname(),
-                member.getCharacterId(),
+                member.getCharacter(),
                 member.isLeader()
         );
     }

--- a/src/main/java/com/team6/team6/member/entity/CharacterType.java
+++ b/src/main/java/com/team6/team6/member/entity/CharacterType.java
@@ -1,0 +1,33 @@
+package com.team6.team6.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CharacterType {
+    RABBIT("토끼", 1),
+    CHICK("병아리", 2),
+    PANDA("판다", 3),
+    FOX("여우", 4),
+    PIG("돼지", 5),
+    TURTLE("거북이", 6),
+    BEAR("곰", 7),
+    UNDEFINED("미지정", 8);
+
+    private final String name;
+    private final int order;
+
+    public static CharacterType fromOrder(int order) {
+        if (order < 1 || order > 7) {
+            return UNDEFINED;
+        }
+
+        for (CharacterType character : values()) {
+            if (character.getOrder() == order) {
+                return character;
+            }
+        }
+        return UNDEFINED;
+    }
+}

--- a/src/main/java/com/team6/team6/member/entity/Member.java
+++ b/src/main/java/com/team6/team6/member/entity/Member.java
@@ -28,6 +28,7 @@ public class Member extends BaseEntity {
     private Room room;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "character_type")
     private CharacterType character;
 
     @Builder

--- a/src/main/java/com/team6/team6/member/entity/Member.java
+++ b/src/main/java/com/team6/team6/member/entity/Member.java
@@ -27,23 +27,26 @@ public class Member extends BaseEntity {
     @JoinColumn(name = "room_id")
     private Room room;
 
-    private Integer characterId;
+    @Enumerated(EnumType.STRING)
+    private CharacterType character;
 
     @Builder
-    private Member(String nickname, String password, boolean isLeader, Room room, Integer characterId) {
+    private Member(String nickname, String password, boolean isLeader, Room room, CharacterType character) {
         this.nickname = nickname;
         this.password = password;
         this.isLeader = isLeader;
         this.room = room;
-        this.characterId = characterId;
+        this.character = character;
     }
 
-    public static Member create(String nickname, String password, Room room, Integer characterId, boolean isLeader) {
+    public static Member create(String nickname, String password, Room room, Integer characterOrder, boolean isLeader) {
+        CharacterType characterType = CharacterType.fromOrder(characterOrder);
+
         return Member.builder()
                 .nickname(nickname)
                 .password(password)
                 .room(room)
-                .characterId(characterId)
+                .character(characterType)
                 .isLeader(isLeader)
                 .build();
     }

--- a/src/main/java/com/team6/team6/member/security/UserPrincipal.java
+++ b/src/main/java/com/team6/team6/member/security/UserPrincipal.java
@@ -1,7 +1,9 @@
 package com.team6.team6.member.security;
 
+import com.team6.team6.member.entity.CharacterType;
 import com.team6.team6.member.entity.Member;
 import lombok.Getter;
+
 import java.io.Serializable;
 
 @Getter
@@ -10,13 +12,13 @@ public class UserPrincipal implements Serializable {
     private final String nickname;
     private final Long roomId;
     private final String roomKey;
-    private final Integer characterId;
+    private final CharacterType character;
 
     public UserPrincipal(Member member) {
         this.id = member.getId();
         this.nickname = member.getNickname();
         this.roomId = member.getRoom().getId();
         this.roomKey = member.getRoom().getRoomKey();
-        this.characterId = member.getCharacterId();
+        this.character = member.getCharacter();
     }
 }

--- a/src/main/java/com/team6/team6/member/service/MemberService.java
+++ b/src/main/java/com/team6/team6/member/service/MemberService.java
@@ -47,21 +47,24 @@ public class MemberService {
 
     private MemberResponse join(Room room, MemberCreateOrLoginServiceRequest request) {
         long currentMemberCount = memberRepository.countByRoomId(room.getId());
-    
+
         if (currentMemberCount >= room.getMaxMember()) {
             throw new IllegalStateException("방의 최대 인원 수에 도달했습니다. 가입할 수 없습니다.");
         }
-    
+
         boolean isFirstMember = currentMemberCount == 0;
-    
+
+        // 멤버 순서에 따라 캐릭터 번호 할당 (1부터 시작, 8 이상은 미지정으로 처리됨)
+        int characterOrder = (int) currentMemberCount + 1;
+
         Member newMember = Member.create(
                 request.nickname(),
                 passwordEncoder.encode(request.password()),
                 room,
-                1,
+                characterOrder,
                 isFirstMember
         );
-    
+
         Member savedMember = memberRepository.save(newMember);
         authenticateUser(savedMember);
         return MemberResponse.from(savedMember);

--- a/src/main/java/com/team6/team6/room/dto/RoomResult.java
+++ b/src/main/java/com/team6/team6/room/dto/RoomResult.java
@@ -1,5 +1,7 @@
 package com.team6.team6.room.dto;
 
+import com.team6.team6.member.entity.CharacterType;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -12,7 +14,7 @@ public record RoomResult(
         List<String> mostMatchedHobbyUserNames,
         int matchedHobbyCount,
         String requestMemberName,
-        Integer requestMemberCharacterId
+        CharacterType requestMemberCharacter
 ) {
 
     public static RoomResult of(
@@ -21,7 +23,7 @@ public record RoomResult(
             List<MemberKeywordCount> topKeywordContributors,
             List<MemberKeywordCount> mostSharedKeywordUsers,
             String requestMemberName,
-            Integer requestMemberCharacterId
+            CharacterType requestMemberCharacter
     ) {
         String formattedDuration = formatDuration(totalDuration);
 
@@ -41,7 +43,7 @@ public record RoomResult(
                 mostMatchedHobbyUserNames,
                 matchedHobbyCount,
                 requestMemberName,
-                requestMemberCharacterId
+                requestMemberCharacter
         );
     }
 

--- a/src/main/java/com/team6/team6/room/service/RoomService.java
+++ b/src/main/java/com/team6/team6/room/service/RoomService.java
@@ -2,8 +2,9 @@ package com.team6.team6.room.service;
 
 import com.team6.team6.global.error.exception.NotFoundException;
 import com.team6.team6.keyword.domain.AnalysisResultStore;
-import com.team6.team6.room.domain.RoomExpiryManager;
+import com.team6.team6.member.entity.CharacterType;
 import com.team6.team6.member.security.UserPrincipal;
+import com.team6.team6.room.domain.RoomExpiryManager;
 import com.team6.team6.room.dto.MemberKeywordCount;
 import com.team6.team6.room.dto.RoomCreateServiceRequest;
 import com.team6.team6.room.dto.RoomResponse;
@@ -110,12 +111,12 @@ public class RoomService {
         // 5. 요청한 멤버 정보 가져오기
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String requestMemberName = ANONYMOUS_MEMBER;
-        Integer requestMemberCharacterId = null;
+        CharacterType requestMemberCharacter = null;
 
         if (authentication != null && authentication.getPrincipal() instanceof UserPrincipal) {
             UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
             requestMemberName = userPrincipal.getNickname();
-            requestMemberCharacterId = userPrincipal.getCharacterId();
+            requestMemberCharacter = userPrincipal.getCharacter();
         }
 
         return RoomResult.of(
@@ -124,7 +125,7 @@ public class RoomService {
                 topKeywordContributors,
                 mostSharedKeywordUsers,
                 requestMemberName,
-                requestMemberCharacterId
+                requestMemberCharacter
         );
     }
 

--- a/src/test/java/com/team6/team6/member/controller/MemberControllerDocsTest.java
+++ b/src/test/java/com/team6/team6/member/controller/MemberControllerDocsTest.java
@@ -2,6 +2,7 @@ package com.team6.team6.member.controller;
 
 import com.team6.team6.global.config.SecurityConfig;
 import com.team6.team6.member.dto.MemberResponse;
+import com.team6.team6.member.entity.CharacterType;
 import com.team6.team6.member.service.MemberService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,8 +44,8 @@ class MemberControllerDocsTest {
     void 회원_가입_또는_로그인_정상_요청_테스트() throws Exception {
         // given
         String roomKey = "room123";
-        MemberResponse memberResponse = new MemberResponse("tester", 1, true);
-        
+        MemberResponse memberResponse = new MemberResponse("tester", CharacterType.RABBIT, true);
+
         given(memberService.joinOrLogin(any(), any())).willReturn(memberResponse);
 
         // Request body
@@ -81,7 +82,7 @@ class MemberControllerDocsTest {
                                         .description("응답 메시지"),
                                 fieldWithPath("data").description("회원 정보"),
                                 fieldWithPath("data.nickname").description("회원 닉네임"),
-                                fieldWithPath("data.characterId").description("캐릭터 ID"),
+                                fieldWithPath("data.character").description("회원 캐릭터"),
                                 fieldWithPath("data.isLeader").description("방장 여부")
                         )
                 ));

--- a/src/test/java/com/team6/team6/member/service/MemberServiceTest.java
+++ b/src/test/java/com/team6/team6/member/service/MemberServiceTest.java
@@ -3,6 +3,7 @@ package com.team6.team6.member.service;
 import com.team6.team6.member.domain.MemberRepository;
 import com.team6.team6.member.dto.MemberCreateOrLoginServiceRequest;
 import com.team6.team6.member.dto.MemberResponse;
+import com.team6.team6.member.entity.CharacterType;
 import com.team6.team6.member.entity.Member;
 import com.team6.team6.member.security.UserPrincipal;
 import com.team6.team6.room.dto.RoomCreateServiceRequest;
@@ -42,7 +43,7 @@ class MemberServiceTest {
 
     @Autowired
     private RoomRepository roomRepository;
-    
+
     @Test
     void 신규_멤버_가입_성공() {
         // given
@@ -51,27 +52,27 @@ class MemberServiceTest {
         );
         RoomResponse roomResponse = roomService.createRoom(roomRequest);
         String roomKey = roomResponse.roomKey();
-        
+
         MemberCreateOrLoginServiceRequest memberRequest = MemberCreateOrLoginServiceRequest.builder()
                 .nickname("테스트유저")
                 .password("test123!")
                 .build();
-                
+
         // when
         MemberResponse response = memberService.joinOrLogin(roomKey, memberRequest);
-        
+
         // then
         assertSoftly(softly -> {
             softly.assertThat(response).isNotNull();
             softly.assertThat(response.nickname()).isEqualTo("테스트유저");
-            softly.assertThat(response.characterId()).isEqualTo(1);
+            softly.assertThat(response.character()).isEqualTo(CharacterType.RABBIT); // CharacterType.RABBIT로 변경
             softly.assertThat(response.isLeader()).isTrue(); // 첫 번째 멤버는 리더
-            
+
             // 실제 DB에 저장되었는지 확인
             Room room = roomRepository.findByRoomKey(roomKey).orElseThrow();
             Member member = memberRepository.findByNicknameAndRoomId("테스트유저", room.getId()).orElseThrow();
             softly.assertThat(member.isLeader()).isTrue();
-            
+
             // 인증 상태 확인
             softly.assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
         });

--- a/src/test/java/com/team6/team6/room/controller/RoomControllerDocsTest.java
+++ b/src/test/java/com/team6/team6/room/controller/RoomControllerDocsTest.java
@@ -2,6 +2,7 @@ package com.team6.team6.room.controller;
 
 import com.team6.team6.global.CustomRestDocsHandler;
 import com.team6.team6.global.RestDocsSupport;
+import com.team6.team6.member.entity.CharacterType;
 import com.team6.team6.room.dto.RoomCreateRequest;
 import com.team6.team6.room.dto.RoomResponse;
 import com.team6.team6.room.dto.RoomResult;
@@ -192,7 +193,7 @@ public class RoomControllerDocsTest extends RestDocsSupport {
                 mostMatchedUsers,
                 2,
                 "member1",
-                1
+                CharacterType.RABBIT
         );
 
         given(roomService.getRoomResult("abc123")).willReturn(mockResult);
@@ -226,8 +227,8 @@ public class RoomControllerDocsTest extends RestDocsSupport {
                                         .description("최다 공감 키워드 수"),
                                 fieldWithPath("data.requestMemberName").type(JsonFieldType.STRING)
                                         .description("요청한 멤버 이름"),
-                                fieldWithPath("data.requestMemberCharacterId").type(JsonFieldType.NUMBER)
-                                        .description("요청한 멤버의 캐릭터 ID")
+                                fieldWithPath("data.requestMemberCharacter").type(JsonFieldType.STRING)
+                                        .description("요청한 멤버의 캐릭터")
                         )
                 ));
     }

--- a/src/test/java/com/team6/team6/room/dto/RoomResultTest.java
+++ b/src/test/java/com/team6/team6/room/dto/RoomResultTest.java
@@ -1,5 +1,6 @@
 package com.team6.team6.room.dto;
 
+import com.team6.team6.member.entity.CharacterType;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -27,7 +28,7 @@ class RoomResultTest {
         );
 
         String requestMemberName = "사용자1";
-        Integer requestMemberCharacterId = 1;
+        CharacterType requestMemberCharacter = CharacterType.RABBIT;
 
         // when
         RoomResult result = RoomResult.of(
@@ -36,7 +37,7 @@ class RoomResultTest {
                 topKeywordContributors,
                 mostSharedKeywordUsers,
                 requestMemberName,
-                requestMemberCharacterId
+                requestMemberCharacter
         );
 
         // then
@@ -48,7 +49,7 @@ class RoomResultTest {
             softly.assertThat(result.mostMatchedHobbyUserNames()).containsExactly("사용자3", "사용자4");
             softly.assertThat(result.matchedHobbyCount()).isEqualTo(3);
             softly.assertThat(result.requestMemberName()).isEqualTo("사용자1");
-            softly.assertThat(result.requestMemberCharacterId()).isEqualTo(1);
+            softly.assertThat(result.requestMemberCharacter()).isEqualTo(CharacterType.RABBIT);
         });
     }
 
@@ -58,7 +59,7 @@ class RoomResultTest {
         List<String> sharedKeywords = List.of("여행");
         List<MemberKeywordCount> contributors = List.of(new MemberKeywordCount("사용자1", 1));
         String requestMemberName = "사용자1";
-        Integer requestMemberCharacterId = 1;
+        CharacterType requestMemberCharacter = CharacterType.RABBIT;
 
         // when - 초만 있는 경우
         RoomResult secondsOnly = RoomResult.of(
@@ -67,7 +68,7 @@ class RoomResultTest {
                 contributors,
                 contributors,
                 requestMemberName,
-                requestMemberCharacterId
+                requestMemberCharacter
         );
 
         // when - 분과 초만 있는 경우
@@ -77,7 +78,7 @@ class RoomResultTest {
                 contributors,
                 contributors,
                 requestMemberName,
-                requestMemberCharacterId
+                requestMemberCharacter
         );
 
         // when - 시간, 분, 초가 모두 있는 경우
@@ -87,7 +88,7 @@ class RoomResultTest {
                 contributors,
                 contributors,
                 requestMemberName,
-                requestMemberCharacterId
+                requestMemberCharacter
         );
 
         // then
@@ -105,7 +106,7 @@ class RoomResultTest {
         Duration duration = Duration.ofMinutes(10);
         List<MemberKeywordCount> emptyContributors = Collections.emptyList();
         String requestMemberName = "사용자1";
-        Integer requestMemberCharacterId = 1;
+        CharacterType requestMemberCharacter = CharacterType.RABBIT;
 
         // when
         RoomResult result = RoomResult.of(
@@ -114,7 +115,7 @@ class RoomResultTest {
                 emptyContributors,
                 emptyContributors,
                 requestMemberName,
-                requestMemberCharacterId
+                requestMemberCharacter
         );
 
         // then
@@ -126,7 +127,7 @@ class RoomResultTest {
             softly.assertThat(result.mostMatchedHobbyUserNames()).isEmpty();
             softly.assertThat(result.matchedHobbyCount()).isEqualTo(0);
             softly.assertThat(result.requestMemberName()).isEqualTo("사용자1");
-            softly.assertThat(result.requestMemberCharacterId()).isEqualTo(1);
+            softly.assertThat(result.requestMemberCharacter()).isEqualTo(CharacterType.RABBIT);
         });
     }
 }


### PR DESCRIPTION
## 🔨 작업 사항 


## 캐릭터 타입을 Integer에서 Enum으로 변경

### 변경 내용
- `Member` 엔티티의 `characterId` 필드를 `CharacterType` enum으로 변경
- DB 컬럼명을 `character_id`에서 `character_type`으로 변경
- 관련 서비스 및 DTO 클래스들 수정
- 테스트 코드 반영

### 작업 사항
```java
// CharacterType enum 생성
@Getter
@RequiredArgsConstructor
public enum CharacterType {
    RABBIT("토끼", 1),
    CHICK("병아리", 2),
    PANDA("판다", 3),
    FOX("여우", 4),
    PIG("돼지", 5),
    TURTLE("거북이", 6),
    BEAR("곰", 7),
    UNDEFINED("미지정", 8);

    private final String name;
    private final int order;

    public static CharacterType fromOrder(int order) {
        if (order < 1 || order > 7) {
            return UNDEFINED;
        }

        for (CharacterType character : values()) {
            if (character.getOrder() == order) {
                return character;
            }
        }
        return UNDEFINED;
    }
}

// Member 엔티티 수정 (MySQL 예약어이기에 character_type로 변경)
@Enumerated(EnumType.STRING)
@Column(name = "character_type")
private CharacterType character;

```