### PR TITLE
open ai 문제 수정, 로깅 삽입

### DIFF
--- a/src/main/java/com/team6/team6/global/error/exception/ExternalApiException.java
+++ b/src/main/java/com/team6/team6/global/error/exception/ExternalApiException.java
@@ -1,0 +1,11 @@
+package com.team6.team6.global.error.exception;
+
+public class ExternalApiException extends RuntimeException {
+    public ExternalApiException(String message) {
+        super(message);
+    }
+
+    public ExternalApiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/team6/team6/keyword/exception/AiResponseParsingException.java
+++ b/src/main/java/com/team6/team6/keyword/exception/AiResponseParsingException.java
@@ -1,8 +1,0 @@
-package com.team6.team6.keyword.exception;
-
-public class AiResponseParsingException extends RuntimeException {
-
-    public AiResponseParsingException(Throwable cause) {
-        super("AI 응답을 파싱하는 데 실패했습니다.", cause);
-    }
-}

--- a/src/main/java/com/team6/team6/keyword/infrastructure/OpenAiKeywordSimilarityAnalyser.java
+++ b/src/main/java/com/team6/team6/keyword/infrastructure/OpenAiKeywordSimilarityAnalyser.java
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.team6.team6.global.log.LogUtil.infoLog;
+
 @Component
 @RequiredArgsConstructor
 public class OpenAiKeywordSimilarityAnalyser implements KeywordSimilarityAnalyser {
@@ -20,8 +22,11 @@ public class OpenAiKeywordSimilarityAnalyser implements KeywordSimilarityAnalyse
     @Override
     public List<List<String>> analyse(List<String> keywords) {
         if (keywords == null || keywords.isEmpty()) {
+            infoLog("키워드 유사성 분석 요청이 비어있어 빈 결과 반환");
             return List.of();
         }
+
+        infoLog(String.format("분석 요청 키워드 목록: %s", String.join(", ", keywords)));
 
         String formattedKeywords = keywords.stream()
                 .map(k -> "- " + k)
@@ -44,14 +49,20 @@ public class OpenAiKeywordSimilarityAnalyser implements KeywordSimilarityAnalyse
         Prompt prompt = new Prompt(promptText);
 
         try {
+            infoLog(String.format("OpenAI API 호출 시작 - 키워드 개수: %d", keywords.size()));
             KeywordGroupResponse response = chatClient
                     .prompt(prompt)
                     .call()
                     .entity(KeywordGroupResponse.class);
+            List<List<String>> groups = response.groups();
 
             return response.groups();
         } catch (Exception e) {
             throw new AiResponseParsingException(e);
+            infoLog(String.format("OpenAI로부터 키워드 유사성 분석 완료 - 그룹 수: %d, 입력 키워드 수: %d",
+                    groups.size(), keywords.size()));
+
+            return groups;
         }
     }
 }

--- a/src/main/java/com/team6/team6/keyword/infrastructure/OpenAiKeywordSimilarityAnalyser.java
+++ b/src/main/java/com/team6/team6/keyword/infrastructure/OpenAiKeywordSimilarityAnalyser.java
@@ -1,8 +1,8 @@
 package com.team6.team6.keyword.infrastructure;
 
+import com.team6.team6.global.error.exception.ExternalApiException;
 import com.team6.team6.keyword.domain.KeywordSimilarityAnalyser;
 import com.team6.team6.keyword.dto.KeywordGroupResponse;
-import com.team6.team6.keyword.exception.AiResponseParsingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.prompt.Prompt;
@@ -56,13 +56,12 @@ public class OpenAiKeywordSimilarityAnalyser implements KeywordSimilarityAnalyse
                     .entity(KeywordGroupResponse.class);
             List<List<String>> groups = response.groups();
 
-            return response.groups();
-        } catch (Exception e) {
-            throw new AiResponseParsingException(e);
             infoLog(String.format("OpenAI로부터 키워드 유사성 분석 완료 - 그룹 수: %d, 입력 키워드 수: %d",
                     groups.size(), keywords.size()));
 
             return groups;
+        } catch (RuntimeException e) {
+            throw new ExternalApiException("OpenAI 키워드 유사성 분석 실패", e);
         }
     }
 }

--- a/src/main/java/com/team6/team6/question/infrastructure/OpenAiQuestionGenerator.java
+++ b/src/main/java/com/team6/team6/question/infrastructure/OpenAiQuestionGenerator.java
@@ -10,6 +10,8 @@ import org.springframework.stereotype.Component;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.team6.team6.global.log.LogUtil.infoLog;
+
 @Component
 @RequiredArgsConstructor
 public class OpenAiQuestionGenerator implements QuestionGenerator {
@@ -42,11 +44,16 @@ public class OpenAiQuestionGenerator implements QuestionGenerator {
         Prompt prompt = new Prompt(promptText);
 
         try {
+            infoLog(String.format("OpenAI API 호출 시작 - 키워드: %s", keyword));
             QuestionsResponse response = chatClient.prompt(prompt)
                     .call()
                     .entity(QuestionsResponse.class);
 
-            return parseQuestions(response.questions());
+            List<String> parsedQuestions = parseQuestions(response.questions());
+            infoLog(String.format("OpenAI로부터 질문 생성 완료 - 키워드: %s, 생성된 질문 개수: %d",
+                    keyword, parsedQuestions.size()));
+
+            return parsedQuestions;
         } catch (Exception e) {
             throw new RuntimeException("OpenAI 질문 생성 실패: " + e.getMessage(), e);
         }

--- a/src/main/java/com/team6/team6/question/infrastructure/OpenAiQuestionGenerator.java
+++ b/src/main/java/com/team6/team6/question/infrastructure/OpenAiQuestionGenerator.java
@@ -1,5 +1,6 @@
 package com.team6.team6.question.infrastructure;
 
+import com.team6.team6.global.error.exception.ExternalApiException;
 import com.team6.team6.question.domain.QuestionGenerator;
 import com.team6.team6.question.dto.QuestionsResponse;
 import lombok.RequiredArgsConstructor;
@@ -55,7 +56,7 @@ public class OpenAiQuestionGenerator implements QuestionGenerator {
 
             return parsedQuestions;
         } catch (Exception e) {
-            throw new RuntimeException("OpenAI 질문 생성 실패: " + e.getMessage(), e);
+            throw new ExternalApiException("OpenAI 질문 생성 실패", e);
         }
     }
 

--- a/src/main/java/com/team6/team6/question/infrastructure/OpenAiQuestionGenerator.java
+++ b/src/main/java/com/team6/team6/question/infrastructure/OpenAiQuestionGenerator.java
@@ -31,12 +31,12 @@ public class OpenAiQuestionGenerator implements QuestionGenerator {
                 - 결과를 JSON 형식의 질문 목록으로 반환해줘, "questions" 키에 질문 배열이 담겨야 함
                 
                 예시 응답 형식:
-                {
-                  "questions": [
+                \\{
+                  "questions": \\[
                     "롤에서 맞라인으로 나왔을 때 가장 싫은 챔피언은?",
                     "첫 번째 롤 챔피언은 뭐였어?"
-                  ]
-                }
+                  \\]
+                \\}
                 """, keyword);
 
         Prompt prompt = new Prompt(promptText);

--- a/src/test/java/com/team6/team6/keyword/infrastructure/OpenAiKeywordSimilarityAnalyserTest.java
+++ b/src/test/java/com/team6/team6/keyword/infrastructure/OpenAiKeywordSimilarityAnalyserTest.java
@@ -1,7 +1,7 @@
 package com.team6.team6.keyword.infrastructure;
 
+import com.team6.team6.global.error.exception.ExternalApiException;
 import com.team6.team6.keyword.dto.KeywordGroupResponse;
-import com.team6.team6.keyword.exception.AiResponseParsingException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.ai.chat.client.ChatClient;
@@ -73,7 +73,7 @@ class OpenAiKeywordSimilarityAnalyserTest {
 
         // then
         assertThatThrownBy(() -> analyser.analyse(input))
-                .isInstanceOf(AiResponseParsingException.class)
+                .isInstanceOf(ExternalApiException.class)
                 .hasCauseInstanceOf(RuntimeException.class);
     }
 }

--- a/src/test/java/com/team6/team6/question/infrastructure/OpenAiQuestionGeneratorTest.java
+++ b/src/test/java/com/team6/team6/question/infrastructure/OpenAiQuestionGeneratorTest.java
@@ -1,5 +1,6 @@
 package com.team6.team6.question.infrastructure;
 
+import com.team6.team6.global.error.exception.ExternalApiException;
 import com.team6.team6.question.dto.QuestionsResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -74,7 +75,7 @@ class OpenAiQuestionGeneratorTest {
 
         // then
         assertThatThrownBy(() -> questionGenerator.generateQuestions(keyword))
-                .isInstanceOf(RuntimeException.class)
+                .isInstanceOf(ExternalApiException.class)
                 .hasMessageContaining("OpenAI 질문 생성 실패");
     }
 }


### PR DESCRIPTION
## 🔨 작업 사항 
### open ai 이스케이프 문자 추가
`문제 상황`
- open ai api 요청에 사용되는 문자열에서 중괄호와 대괄호가 내부적으로 템플릿 변수나 제어문으로 인식되었습니다.

`해결 방법`
- 이스케이프 문자 추가
```java
String promptText = String.format("""
                키워드: %s
                
                이 키워드를 주제로, 처음 만난 사람들이 편하게 이야기 나눌 수 있도록 대화형 질문 20개를 만들어줘.
                
                아래 기준을 지켜줘:
                - 너무 딱딱하거나 교과서적인 말투는 피하고, 자연스럽고 구어체로 작성해
                - 경험, 취향, 감정을 물을 수 있는 질문이 좋고, '너라면 어때?' 식의 접근도 괜찮아
                - 질문 하나당 한 줄로 만들어줘
                - 숫자나 기호 없이 질문 내용만 출력해
                - 결과를 JSON 형식의 질문 목록으로 반환해줘, "questions" 키에 질문 배열이 담겨야 함
                
                예시 응답 형식:
                \\{
                  "questions": \\[
                    "롤에서 맞라인으로 나왔을 때 가장 싫은 챔피언은?",
                    "첫 번째 롤 챔피언은 뭐였어?"
                  \\]
                \\}
                """, keyword);
```

### info 로그 출력
`문제 상황`
- 에러 로그 발견 이후 정확히 어디서 문제가 발생한 것인지 알기 어려웠습니다.

`해결 방법`
```java
@Override
    public List<String> generateQuestions(String keyword) {
        ...
        try {
            infoLog(String.format("OpenAI API 호출 시작 - 키워드: %s", keyword));
            QuestionsResponse response = chatClient.prompt(prompt)
                    .call()
                    .entity(QuestionsResponse.class);

            List<String> parsedQuestions = parseQuestions(response.questions());
            infoLog(String.format("OpenAI로부터 질문 생성 완료 - 키워드: %s, 생성된 질문 개수: %d",
                    keyword, parsedQuestions.size()));

            return parsedQuestions;
        } catch (Exception e) {
            throw new ExternalApiException("OpenAI 질문 생성 실패", e);
        }
    }

@Override
    public List<List<String>> analyse(List<String> keywords) {
        if (keywords == null || keywords.isEmpty()) {
            infoLog("키워드 유사성 분석 요청이 비어있어 빈 결과 반환");
            return List.of();
        }

        infoLog(String.format("분석 요청 키워드 목록: %s", String.join(", ", keywords)));

        ...

        try {
            infoLog(String.format("OpenAI API 호출 시작 - 키워드 개수: %d", keywords.size()));
            KeywordGroupResponse response = chatClient
                    .prompt(prompt)
                    .call()
                    .entity(KeywordGroupResponse.class);
            List<List<String>> groups = response.groups();

            infoLog(String.format("OpenAI로부터 키워드 유사성 분석 완료 - 그룹 수: %d, 입력 키워드 수: %d",
                    groups.size(), keywords.size()));

            return groups;
        } catch (RuntimeException e) {
            throw new ExternalApiException("OpenAI 키워드 유사성 분석 실패", e);
        }
    }
```
- open ai api 호출 전/후 info 로그를 삽입했습니다.

```java
@RestControllerAdvice
public class GlobalExceptionHandler {

    @ResponseStatus(HttpStatus.NOT_FOUND)
    @ExceptionHandler(NotFoundException.class)
    public ApiResponse<Object> handleNotFoundException(NotFoundException e) {
        errorLog("리소스를 찾을 수 없습니다", e);
        return ApiResponse.of(
                HttpStatus.NOT_FOUND,
                e.getMessage(),
                null
        );
    }

    @ResponseStatus(HttpStatus.BAD_REQUEST)
    @ExceptionHandler(BindException.class)
    public ApiResponse<Object> handleBindException(BindException e) {
        List<String> errorMessages = e.getBindingResult().getAllErrors().stream()
                .map(DefaultMessageSourceResolvable::getDefaultMessage)
                .collect(Collectors.toList());

        errorLog("잘못된 파라미터 바인딩", e);

        return ApiResponse.of(
                HttpStatus.BAD_REQUEST,
                "잘못된 파라미터",
                errorMessages.isEmpty() ? List.of("유효하지 않은 요청입니다") : errorMessages
        );
    }

    @ResponseStatus(HttpStatus.BAD_REQUEST)
    @ExceptionHandler(MethodArgumentNotValidException.class)
    public ApiResponse<Object> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
        List<String> errorMessages = e.getBindingResult().getAllErrors().stream()
                .map(DefaultMessageSourceResolvable::getDefaultMessage)
                .collect(Collectors.toList());

        errorLog("유효성 검증 실패", e);

        return ApiResponse.of(
                HttpStatus.BAD_REQUEST,
                "잘못된 파라미터",
                errorMessages.isEmpty() ? List.of("유효하지 않은 요청입니다") : errorMessages
        );
    }

    @ResponseStatus(HttpStatus.BAD_REQUEST)
    @ExceptionHandler({IllegalStateException.class, IllegalArgumentException.class})
    public ApiResponse<Object> handleIllegalStateException(Exception e) {
        errorLog("잘못된 요청", e);

        List<String> errorMessages = List.of(e.getMessage());

        return ApiResponse.of(
                HttpStatus.BAD_REQUEST,
                "잘못된 요청",
                errorMessages
        );
    }

    @ResponseStatus(HttpStatus.BAD_REQUEST)
    @ExceptionHandler(HttpMessageNotReadableException.class)
    public ApiResponse<Object> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
        errorLog("요청 본문을 읽을 수 없습니다", e);

        return ApiResponse.of(
                HttpStatus.BAD_REQUEST,
                "잘못된 파라미터",
                List.of("요청 본문이 필요합니다")
        );
    }

    @ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
    @ExceptionHandler(ExternalApiException.class)
    public ApiResponse<Object> handleExternalApiException(ExternalApiException e) {
        errorLog("외부 API 호출 실패", e);

        return ApiResponse.of(
                HttpStatus.SERVICE_UNAVAILABLE,
                "외부 서비스 일시적 오류",
                List.of("잠시 후 다시 시도해주세요")
        );
    }
}
```
- GlobalExceptionHandler의 모든 핸들러 부분에 error 로그를 삽입했습니다.
- open ai api 등 외부 API 요청 실패 처리를 위해 커스텀 에러 클래스 `ExternalApiException`를 만들었습니다. 
