### PR TITLE
파라미터 유효성 검증 처리

### DIFF
--- a/src/docs/asciidoc/questions.adoc
+++ b/src/docs/asciidoc/questions.adoc
@@ -21,3 +21,18 @@ include::{snippets}/question-controller-test/get/http-request.adoc[]
 include::{snippets}/question-controller-test/get/response-fields.adoc[]
 include::{snippets}/question-controller-test/get/response-body.adoc[]
 
+=== 오류 응답
+
+==== 1. 키워드가 빈 문자열인 경우
+
+빈 키워드로 요청 시 400 Bad Request 응답을 반환합니다.
+
+include::{snippets}/question-controller-test/get-empty-keyword-error/response-fields.adoc[]
+include::{snippets}/question-controller-test/get-empty-keyword-error/response-body.adoc[]
+
+==== 2. 키워드 파라미터가 누락된 경우
+
+필수 파라미터인 keyword가 요청에 포함되지 않은 경우 400 Bad Request 응답을 반환합니다.
+
+include::{snippets}/question-controller-test/get-missing-keyword-error/response-fields.adoc[]
+include::{snippets}/question-controller-test/get-missing-keyword-error/response-body.adoc[]

--- a/src/test/java/com/team6/team6/question/controller/QuestionControllerTest.java
+++ b/src/test/java/com/team6/team6/question/controller/QuestionControllerTest.java
@@ -70,6 +70,49 @@ class QuestionControllerTest {
                 ));
     }
 
+    @Test
+    void 키워드_누락_테스트() throws Exception {
+        // when & then
+        mockMvc.perform(get("/questions")
+                        .param("keyword", ""))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andDo(customDocument(
+                        "get-empty-keyword-error",
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                        .description("결과 코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING)
+                                        .description("HTTP 상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("응답 메시지"),
+                                fieldWithPath("data").type(JsonFieldType.ARRAY)
+                                        .description("에러 메시지 목록")
+                        )
+                ));
+    }
+
+    @Test
+    void 키워드_파라미터_누락_테스트() throws Exception {
+        // when & then
+        mockMvc.perform(get("/questions"))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andDo(customDocument(
+                        "get-missing-keyword-error",
+                        responseFields(
+                                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                                        .description("결과 코드"),
+                                fieldWithPath("status").type(JsonFieldType.STRING)
+                                        .description("HTTP 상태"),
+                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                        .description("응답 메시지"),
+                                fieldWithPath("data").type(JsonFieldType.ARRAY)
+                                        .description("에러 메시지 목록")
+                        )
+                ));
+    }
+
     @TestConfiguration
     static class TestConfig {
 


### PR DESCRIPTION
## 🔨 작업 사항 
### 파라미터 유효성 검증 실패 처리
`문제 상황`
- 요청 바디의 유효성 검증과 파라미터 유효성 검증의 에러가 다름
  - 요청 바디 유효성 검증 실패 시: `MethodArgumentNotValidException` 발생
  - 파라미터 유효성 검증 실패 시: `ConstraintViolationException` 발생
  - 파라미터 자체가 없을 경우: `MissingServletRequestParameterException` 발생

`해결 방법`
- 처리되지 않은 예외를 `GlobalExceptionHandler`에서 처리하도록 했습니다.
```java
@ResponseStatus(HttpStatus.BAD_REQUEST)
    @ExceptionHandler(ConstraintViolationException.class)
    public ApiResponse<Object> handleConstraintViolationException(ConstraintViolationException e) {
        List<String> errorMessages = e.getConstraintViolations().stream()
                .map(ConstraintViolation::getMessage)
                .collect(Collectors.toList());

        errorLog("요청 파라미터 검증 실패", e);

        return ApiResponse.of(
                HttpStatus.BAD_REQUEST,
                "잘못된 파라미터",
                errorMessages.isEmpty() ? List.of("유효하지 않은 요청입니다") : errorMessages
        );
    }

    @ResponseStatus(HttpStatus.BAD_REQUEST)
    @ExceptionHandler(MissingServletRequestParameterException.class)
    public ApiResponse<Object> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
        errorLog("필수 파라미터 누락", e);

        return ApiResponse.of(
                HttpStatus.BAD_REQUEST,
                "잘못된 파라미터",
                List.of(e.getParameterName() + " 파라미터가 필요합니다")
        );
    }
```

### 예외 처리 테스트와 API 문서에 반영
```java
@Test
    void 키워드_누락_테스트() throws Exception {
        // when & then
        mockMvc.perform(get("/questions")
                        .param("keyword", ""))
                .andDo(print())
                .andExpect(status().isBadRequest())
                .andDo(customDocument(
                        "get-empty-keyword-error",
                        responseFields(
                                fieldWithPath("code").type(JsonFieldType.NUMBER)
                                        .description("결과 코드"),
                                fieldWithPath("status").type(JsonFieldType.STRING)
                                        .description("HTTP 상태"),
                                fieldWithPath("message").type(JsonFieldType.STRING)
                                        .description("응답 메시지"),
                                fieldWithPath("data").type(JsonFieldType.ARRAY)
                                        .description("에러 메시지 목록")
                        )
                ));
    }

    @Test
    void 키워드_파라미터_누락_테스트() throws Exception {
        // when & then
        mockMvc.perform(get("/questions"))
                .andDo(print())
                .andExpect(status().isBadRequest())
                .andDo(customDocument(
                        "get-missing-keyword-error",
                        responseFields(
                                fieldWithPath("code").type(JsonFieldType.NUMBER)
                                        .description("결과 코드"),
                                fieldWithPath("status").type(JsonFieldType.STRING)
                                        .description("HTTP 상태"),
                                fieldWithPath("message").type(JsonFieldType.STRING)
                                        .description("응답 메시지"),
                                fieldWithPath("data").type(JsonFieldType.ARRAY)
                                        .description("에러 메시지 목록")
                        )
                ));
    }
```
- 예외 처리에 대해 테스트를 추가했고, 이를 문서에 반영했습니다.

