### PR TITLE
유저 입장시 분석 결과 브로드캐스팅

### DIFF
--- a/src/main/java/com/team6/team6/keyword/domain/KeywordManager.java
+++ b/src/main/java/com/team6/team6/keyword/domain/KeywordManager.java
@@ -21,6 +21,12 @@ public class KeywordManager {
         return analyzeAndSave(roomId);
     }
 
+    // 분석 결과를 가져온다.
+    public List<AnalysisResult> getAnalysisResult(Long roomId) {
+        return analysisResultStore.findByRoomId(roomId);
+    }
+
+
     public List<AnalysisResult> analyzeKeywords(Long roomId) {
         // 먼저 analysisResultStore에서 결과가 있는지 확인
         List<AnalysisResult> storedResults = analysisResultStore.findByRoomId(roomId);

--- a/src/test/java/com/team6/team6/keyword/domain/KeywordManagerTest.java
+++ b/src/test/java/com/team6/team6/keyword/domain/KeywordManagerTest.java
@@ -189,4 +189,50 @@ class KeywordManagerTest {
         verify(analysisResultStore).findByRoomId(roomId);
         verifyNoInteractions(keywordStore, analyser);
     }
+
+    @Test
+    void getAnalysisResult_저장된_결과_반환_테스트() {
+        // given
+        Long roomId = 1L;
+        List<AnalysisResult> expectedResults = List.of(
+                AnalysisResult.of("AI", List.of("AI", "Deep Learning")),
+                AnalysisResult.of("Java", List.of("Java", "JavaScript"))
+        );
+
+        when(analysisResultStore.findByRoomId(roomId)).thenReturn(expectedResults);
+
+        // when
+        List<AnalysisResult> results = keywordManager.getAnalysisResult(roomId);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(results).isEqualTo(expectedResults);
+            softly.assertThat(results).hasSize(2);
+            softly.assertThat(results.get(0).referenceName()).isEqualTo("AI");
+            softly.assertThat(results.get(1).referenceName()).isEqualTo("Java");
+        });
+
+        verify(analysisResultStore).findByRoomId(roomId);
+        verifyNoInteractions(keywordStore, analyser);
+    }
+
+    @Test
+    void getAnalysisResult_빈_결과_반환_테스트() {
+        // given
+        Long roomId = 1L;
+        List<AnalysisResult> emptyResults = List.of();
+
+        when(analysisResultStore.findByRoomId(roomId)).thenReturn(emptyResults);
+
+        // when
+        List<AnalysisResult> results = keywordManager.getAnalysisResult(roomId);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(results).isEmpty();
+        });
+
+        verify(analysisResultStore).findByRoomId(roomId);
+        verifyNoInteractions(keywordStore, analyser);
+    }
 }


### PR DESCRIPTION
## 유저 입장시 분석 결과 브로드캐스팅
- [X] 유저 입장시 분석 결과 브로드캐스팅


## 🔨 작업 사항

### 유저 입장시 분석 결과 브로드캐스팅
- keywordManager에 분석 결과를 가져오는 메서드 추가
```java
// 분석 결과를 가져온다.
    public List<AnalysisResult> getAnalysisResult(Long roomId) {
        return analysisResultStore.findByRoomId(roomId);
    }
```
- 유저 입장시 분석 결과를 가져와서 브로드캐스팅
```java
// WebSocketSubscribeListener.java
@Override
public void onApplicationEvent(SessionSubscribeEvent event) {
   
    // ...기존 로직들

    // 마지막 키워드 분석 결과 전송
    List<AnalysisResult> results = keywordManager.getAnalysisResult(roomId);
    if (!results.isEmpty()) {
        messagePublisher.publishKeywordAnalysisResult(roomKey, results);
    }
}
```