### PR TITLE
기존 Map 구현체 Redis로 전환

### DIFF
--- a/src/main/java/com/team6/team6/global/config/RedisConfig.java
+++ b/src/main/java/com/team6/team6/global/config/RedisConfig.java
@@ -3,7 +3,10 @@ package com.team6.team6.global.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -16,4 +19,15 @@ public class RedisConfig {
         return container;
     }
 
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.afterPropertiesSet();
+        return template;
+    }
 }

--- a/src/main/java/com/team6/team6/global/config/RedisConfig.java
+++ b/src/main/java/com/team6/team6/global/config/RedisConfig.java
@@ -1,11 +1,12 @@
 package com.team6.team6.global.config;
 
+import com.team6.team6.keyword.dto.AnalysisResults;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -19,15 +20,15 @@ public class RedisConfig {
         return container;
     }
 
+    // AnalysisResults 객체를 Redis에 저장하기 위한 RedisTemplate을 생성합니다.
     @Bean
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, Object> template = new RedisTemplate<>();
+    public RedisTemplate<String, AnalysisResults> analysisResultsRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, AnalysisResults> template = new RedisTemplate<>();
+        Jackson2JsonRedisSerializer<AnalysisResults> serializer =
+                new Jackson2JsonRedisSerializer<>(AnalysisResults.class);
         template.setConnectionFactory(connectionFactory);
         template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
-        template.setHashKeySerializer(new StringRedisSerializer());
-        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
-        template.afterPropertiesSet();
+        template.setValueSerializer(serializer);
         return template;
     }
 }

--- a/src/main/java/com/team6/team6/keyword/domain/AnalysisResultStore.java
+++ b/src/main/java/com/team6/team6/keyword/domain/AnalysisResultStore.java
@@ -12,4 +12,6 @@ public interface AnalysisResultStore {
     List<String> findSharedKeywordsByRoomId(Long roomId, Integer requiredAgreements);
 
     List<String> findReferenceNamesByRoomId(Long roomId, Integer requiredAgreements);
+
+    void deleteByRoomId(Long roomId);
 }

--- a/src/main/java/com/team6/team6/keyword/domain/KeywordStore.java
+++ b/src/main/java/com/team6/team6/keyword/domain/KeywordStore.java
@@ -7,4 +7,6 @@ public interface KeywordStore {
     void saveKeyword(Long roomId, String keyword);
 
     List<String> getKeywords(Long roomId);
+
+    void deleteKeywordsByRoomId(Long roomId);
 }

--- a/src/main/java/com/team6/team6/keyword/dto/AnalysisResult.java
+++ b/src/main/java/com/team6/team6/keyword/dto/AnalysisResult.java
@@ -1,8 +1,9 @@
 package com.team6.team6.keyword.dto;
 
+import java.io.Serializable;
 import java.util.List;
 
-public record AnalysisResult(String referenceName, int count, List<String> variations) {
+public record AnalysisResult(String referenceName, int count, List<String> variations) implements Serializable {
 
     public static AnalysisResult of(String referenceName, List<String> variations) {
         return new AnalysisResult(referenceName, variations.size(), variations);

--- a/src/main/java/com/team6/team6/keyword/dto/AnalysisResults.java
+++ b/src/main/java/com/team6/team6/keyword/dto/AnalysisResults.java
@@ -1,0 +1,33 @@
+package com.team6.team6.keyword.dto;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record AnalysisResults(List<AnalysisResult> results) implements Serializable {
+
+    public static AnalysisResults of(List<AnalysisResult> results) {
+        return new AnalysisResults(results);
+    }
+
+    public static AnalysisResults empty() {
+        return new AnalysisResults(new ArrayList<>());
+    }
+
+    public List<String> findSharedKeywords(Integer requiredAgreements) {
+        return results.stream()
+                .filter(result -> result.count() >= requiredAgreements)
+                .flatMap(result -> result.variations().stream())
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    public List<String> findReferenceNames(Integer requiredAgreements) {
+        return results.stream()
+                .filter(result -> result.count() >= requiredAgreements)
+                .map(AnalysisResult::referenceName)
+                .distinct()
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/team6/team6/keyword/infrastructure/InMemoryAnalysisResultStore.java
+++ b/src/main/java/com/team6/team6/keyword/infrastructure/InMemoryAnalysisResultStore.java
@@ -2,6 +2,7 @@ package com.team6.team6.keyword.infrastructure;
 
 import com.team6.team6.keyword.domain.AnalysisResultStore;
 import com.team6.team6.keyword.dto.AnalysisResult;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -11,6 +12,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Component
+@Profile("test")
 public class InMemoryAnalysisResultStore implements AnalysisResultStore {
 
     // 방 ID를 키로 하고, 해당 방의 분석 결과 리스트를 값으로 하는 맵
@@ -48,5 +50,10 @@ public class InMemoryAnalysisResultStore implements AnalysisResultStore {
                 .map(AnalysisResult::referenceName)
                 .distinct()
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public void deleteByRoomId(Long roomId) {
+        resultStore.remove(roomId);
     }
 }

--- a/src/main/java/com/team6/team6/keyword/infrastructure/MemoryMapKeywordStore.java
+++ b/src/main/java/com/team6/team6/keyword/infrastructure/MemoryMapKeywordStore.java
@@ -1,12 +1,14 @@
 package com.team6.team6.keyword.infrastructure;
 
 import com.team6.team6.keyword.domain.KeywordStore;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Component
+@Profile("test")
 public class MemoryMapKeywordStore implements KeywordStore {
 
     private final Map<Long, List<String>> keywordStore = new ConcurrentHashMap<>();
@@ -22,5 +24,10 @@ public class MemoryMapKeywordStore implements KeywordStore {
     @Override
     public List<String> getKeywords(Long roomId) {
         return keywordStore.getOrDefault(roomId, Collections.emptyList());
+    }
+
+    @Override
+    public void deleteKeywordsByRoomId(Long roomId) {
+        keywordStore.remove(roomId);
     }
 }

--- a/src/main/java/com/team6/team6/keyword/infrastructure/RedisAnalysisResultStore.java
+++ b/src/main/java/com/team6/team6/keyword/infrastructure/RedisAnalysisResultStore.java
@@ -1,0 +1,69 @@
+package com.team6.team6.keyword.infrastructure;
+
+import com.team6.team6.keyword.domain.AnalysisResultStore;
+import com.team6.team6.keyword.dto.AnalysisResult;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@Profile("!test")
+public class RedisAnalysisResultStore implements AnalysisResultStore {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private static final String KEY_PREFIX = "analysis_result:";
+
+    public RedisAnalysisResultStore(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    public void save(Long roomId, List<AnalysisResult> analysisResults) {
+        String key = generateKey(roomId);
+        redisTemplate.opsForValue().set(key, new ArrayList<>(analysisResults));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<AnalysisResult> findByRoomId(Long roomId) {
+        String key = generateKey(roomId);
+        List<AnalysisResult> results = (List<AnalysisResult>) redisTemplate.opsForValue().get(key);
+        return results != null ? results : new ArrayList<>();
+    }
+
+    @Override
+    public List<String> findSharedKeywordsByRoomId(Long roomId, Integer requiredAgreements) {
+        List<AnalysisResult> results = findByRoomId(roomId);
+
+        return results.stream()
+                .filter(result -> result.count() >= requiredAgreements)
+                .flatMap(result -> result.variations().stream())
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<String> findReferenceNamesByRoomId(Long roomId, Integer requiredAgreements) {
+        List<AnalysisResult> results = findByRoomId(roomId);
+
+        return results.stream()
+                .filter(result -> result.count() >= requiredAgreements)
+                .map(AnalysisResult::referenceName)
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void deleteByRoomId(Long roomId) {
+        String key = generateKey(roomId);
+        redisTemplate.delete(key);
+    }
+
+    private String generateKey(Long roomId) {
+        return KEY_PREFIX + roomId;
+    }
+}

--- a/src/main/java/com/team6/team6/keyword/infrastructure/RedisAnalysisResultStore.java
+++ b/src/main/java/com/team6/team6/keyword/infrastructure/RedisAnalysisResultStore.java
@@ -2,6 +2,7 @@ package com.team6.team6.keyword.infrastructure;
 
 import com.team6.team6.keyword.domain.AnalysisResultStore;
 import com.team6.team6.keyword.dto.AnalysisResult;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
@@ -12,14 +13,11 @@ import java.util.stream.Collectors;
 
 @Component
 @Profile("!test")
+@RequiredArgsConstructor
 public class RedisAnalysisResultStore implements AnalysisResultStore {
 
     private static final String KEY_PREFIX = "analysis_result:";
     private final RedisTemplate<String, Object> redisTemplate;
-
-    public RedisAnalysisResultStore(RedisTemplate<String, Object> redisTemplate) {
-        this.redisTemplate = redisTemplate;
-    }
 
     @Override
     public void save(Long roomId, List<AnalysisResult> analysisResults) {

--- a/src/main/java/com/team6/team6/keyword/infrastructure/RedisAnalysisResultStore.java
+++ b/src/main/java/com/team6/team6/keyword/infrastructure/RedisAnalysisResultStore.java
@@ -2,62 +2,65 @@ package com.team6.team6.keyword.infrastructure;
 
 import com.team6.team6.keyword.domain.AnalysisResultStore;
 import com.team6.team6.keyword.dto.AnalysisResult;
+import com.team6.team6.keyword.dto.AnalysisResults;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Component
 @Profile("!test")
 @RequiredArgsConstructor
+@Slf4j
 public class RedisAnalysisResultStore implements AnalysisResultStore {
 
     private static final String KEY_PREFIX = "analysis_result:";
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, AnalysisResults> redisTemplate;
 
     @Override
     public void save(Long roomId, List<AnalysisResult> analysisResults) {
-        String key = generateKey(roomId);
-        redisTemplate.opsForValue().set(key, new ArrayList<>(analysisResults));
+        try {
+            String key = generateKey(roomId);
+            redisTemplate.opsForValue().set(key, AnalysisResults.of(analysisResults));
+        } catch (Exception e) {
+            log.error("분석 결과를 Redis에 저장하는 중 오류 발생: {}", e.getMessage());
+            throw new RuntimeException("분석 결과 저장에 실패했습니다.", e);
+        }
     }
 
     @Override
     public List<AnalysisResult> findByRoomId(Long roomId) {
-        String key = generateKey(roomId);
-        List<AnalysisResult> results = (List<AnalysisResult>) redisTemplate.opsForValue().get(key);
-        return results != null ? results : new ArrayList<>();
+        return getAnalysisResults(roomId).results();
     }
 
     @Override
     public List<String> findSharedKeywordsByRoomId(Long roomId, Integer requiredAgreements) {
-        List<AnalysisResult> results = findByRoomId(roomId);
-
-        return results.stream()
-                .filter(result -> result.count() >= requiredAgreements)
-                .flatMap(result -> result.variations().stream())
-                .distinct()
-                .collect(Collectors.toList());
+        return getAnalysisResults(roomId).findSharedKeywords(requiredAgreements);
     }
 
     @Override
     public List<String> findReferenceNamesByRoomId(Long roomId, Integer requiredAgreements) {
-        List<AnalysisResult> results = findByRoomId(roomId);
-
-        return results.stream()
-                .filter(result -> result.count() >= requiredAgreements)
-                .map(AnalysisResult::referenceName)
-                .distinct()
-                .collect(Collectors.toList());
+        return getAnalysisResults(roomId).findReferenceNames(requiredAgreements);
     }
 
     @Override
     public void deleteByRoomId(Long roomId) {
         String key = generateKey(roomId);
         redisTemplate.delete(key);
+    }
+
+    private AnalysisResults getAnalysisResults(Long roomId) {
+        String key = generateKey(roomId);
+        try {
+            AnalysisResults results = redisTemplate.opsForValue().get(key);
+            return results != null ? results : AnalysisResults.empty();
+        } catch (Exception e) {
+            log.error("분석 결과를 Redis에서 가져오는 중 오류 발생: {}", e.getMessage());
+            throw new RuntimeException("분석 결과 조회에 실패했습니다.", e);
+        }
     }
 
     private String generateKey(Long roomId) {

--- a/src/main/java/com/team6/team6/keyword/infrastructure/RedisAnalysisResultStore.java
+++ b/src/main/java/com/team6/team6/keyword/infrastructure/RedisAnalysisResultStore.java
@@ -14,8 +14,8 @@ import java.util.stream.Collectors;
 @Profile("!test")
 public class RedisAnalysisResultStore implements AnalysisResultStore {
 
-    private final RedisTemplate<String, Object> redisTemplate;
     private static final String KEY_PREFIX = "analysis_result:";
+    private final RedisTemplate<String, Object> redisTemplate;
 
     public RedisAnalysisResultStore(RedisTemplate<String, Object> redisTemplate) {
         this.redisTemplate = redisTemplate;
@@ -27,7 +27,6 @@ public class RedisAnalysisResultStore implements AnalysisResultStore {
         redisTemplate.opsForValue().set(key, new ArrayList<>(analysisResults));
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public List<AnalysisResult> findByRoomId(Long roomId) {
         String key = generateKey(roomId);

--- a/src/main/java/com/team6/team6/keyword/infrastructure/RedisKeywordStore.java
+++ b/src/main/java/com/team6/team6/keyword/infrastructure/RedisKeywordStore.java
@@ -25,7 +25,9 @@ public class RedisKeywordStore implements KeywordStore {
 
     @Override
     public List<String> getKeywords(Long roomId) {
-        return getKeywordsFromRedis(roomId);
+        String key = generateKey(roomId);
+        List<String> result = redisTemplate.opsForList().range(key, 0, -1);
+        return result != null ? result : new ArrayList<>();
     }
 
     @Override
@@ -36,11 +38,5 @@ public class RedisKeywordStore implements KeywordStore {
 
     private String generateKey(Long roomId) {
         return KEY_PREFIX + roomId;
-    }
-
-    private List<String> getKeywordsFromRedis(Long roomId) {
-        String key = generateKey(roomId);
-        List<String> result = redisTemplate.opsForList().range(key, 0, -1);
-        return result != null ? result : new ArrayList<>();
     }
 }

--- a/src/main/java/com/team6/team6/keyword/infrastructure/RedisKeywordStore.java
+++ b/src/main/java/com/team6/team6/keyword/infrastructure/RedisKeywordStore.java
@@ -1,0 +1,51 @@
+package com.team6.team6.keyword.infrastructure;
+
+import com.team6.team6.keyword.domain.KeywordStore;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Component
+@Profile("!test")
+public class RedisKeywordStore implements KeywordStore {
+
+    private static final String KEY_PREFIX = "keywords:";
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public RedisKeywordStore(RedisTemplate<String, Object> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    public void saveKeyword(Long roomId, String keyword) {
+        String key = generateKey(roomId);
+        List<String> keywords = getKeywordsFromRedis(roomId);
+        keywords.add(keyword);
+        redisTemplate.opsForValue().set(key, keywords);
+    }
+
+    @Override
+    public List<String> getKeywords(Long roomId) {
+        return getKeywordsFromRedis(roomId);
+    }
+
+    @Override
+    public void deleteKeywordsByRoomId(Long roomId) {
+        String key = generateKey(roomId);
+        redisTemplate.delete(key);
+    }
+
+    private String generateKey(Long roomId) {
+        return KEY_PREFIX + roomId;
+    }
+
+    private List<String> getKeywordsFromRedis(Long roomId) {
+        String key = generateKey(roomId);
+        List<String> keywords = (List<String>) redisTemplate.opsForValue().get(key);
+        return keywords != null ? keywords : new ArrayList<>();
+    }
+}

--- a/src/main/java/com/team6/team6/question/infrastructure/InMemoryKeywordLockManager.java
+++ b/src/main/java/com/team6/team6/question/infrastructure/InMemoryKeywordLockManager.java
@@ -1,12 +1,14 @@
 package com.team6.team6.question.infrastructure;
 
 import com.team6.team6.question.domain.KeywordLockManager;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 @Component
+@Profile("test")
 public class InMemoryKeywordLockManager implements KeywordLockManager {
 
     private final ConcurrentMap<String, Boolean> lockMap = new ConcurrentHashMap<>();

--- a/src/main/java/com/team6/team6/question/infrastructure/RedisKeywordLockManager.java
+++ b/src/main/java/com/team6/team6/question/infrastructure/RedisKeywordLockManager.java
@@ -1,0 +1,36 @@
+package com.team6.team6.question.infrastructure;
+
+import com.team6.team6.question.domain.KeywordLockManager;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@Profile("!test")
+public class RedisKeywordLockManager implements KeywordLockManager {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String LOCK_PREFIX = "keyword_lock:";
+    private static final long DEFAULT_LOCK_TIMEOUT = 10; // 10초 후 자동 해제
+
+    public RedisKeywordLockManager(RedisTemplate<String, String> redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    @Override
+    public boolean tryLock(String keyword) {
+        String lockKey = LOCK_PREFIX + keyword;
+        return Boolean.TRUE.equals(
+                redisTemplate.opsForValue()
+                        .setIfAbsent(lockKey, "locked", DEFAULT_LOCK_TIMEOUT, TimeUnit.SECONDS)
+        );
+    }
+
+    @Override
+    public void unlock(String keyword) {
+        String lockKey = LOCK_PREFIX + keyword;
+        redisTemplate.delete(lockKey);
+    }
+}

--- a/src/main/java/com/team6/team6/question/infrastructure/RedisKeywordLockManager.java
+++ b/src/main/java/com/team6/team6/question/infrastructure/RedisKeywordLockManager.java
@@ -1,6 +1,7 @@
 package com.team6.team6.question.infrastructure;
 
 import com.team6.team6.question.domain.KeywordLockManager;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
@@ -9,15 +10,12 @@ import java.util.concurrent.TimeUnit;
 
 @Component
 @Profile("!test")
+@RequiredArgsConstructor
 public class RedisKeywordLockManager implements KeywordLockManager {
 
     private final RedisTemplate<String, String> redisTemplate;
     private static final String LOCK_PREFIX = "keyword_lock:";
     private static final long DEFAULT_LOCK_TIMEOUT = 10; // 10초 후 자동 해제
-
-    public RedisKeywordLockManager(RedisTemplate<String, String> redisTemplate) {
-        this.redisTemplate = redisTemplate;
-    }
 
     @Override
     public boolean tryLock(String keyword) {

--- a/src/test/java/com/team6/team6/keyword/dto/AnalysisResultsTest.java
+++ b/src/test/java/com/team6/team6/keyword/dto/AnalysisResultsTest.java
@@ -1,0 +1,111 @@
+package com.team6.team6.keyword.dto;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AnalysisResultsTest {
+
+    @Test
+    void empty_메서드는_빈_결과_목록을_가진_객체를_생성한다() {
+        // when
+        AnalysisResults emptyResults = AnalysisResults.empty();
+
+        // then
+        assertThat(emptyResults.results()).isEmpty();
+    }
+
+    @Test
+    void findSharedKeywords_필터링_정상_동작() {
+        // given
+        List<AnalysisResult> results = Arrays.asList(
+                AnalysisResult.of("자바", Arrays.asList("Java", "JAVA", "자바")), // count: 3
+                AnalysisResult.of("파이썬", Arrays.asList("Python", "파이썬")), // count: 2
+                AnalysisResult.of("C#", Collections.singletonList("C#")) // count: 1
+        );
+        AnalysisResults analysisResults = AnalysisResults.of(results);
+
+        // when
+        List<String> sharedKeywords = analysisResults.findSharedKeywords(3);
+
+        // then
+        assertThat(sharedKeywords).containsExactlyInAnyOrder("Java", "JAVA", "자바");
+    }
+
+    @Test
+    void findSharedKeywords_해당하는_결과가_없으면_빈_리스트_반환() {
+        // given
+        List<AnalysisResult> results = Arrays.asList(
+                AnalysisResult.of("자바", Arrays.asList("Java", "JAVA", "자바")), // count: 3
+                AnalysisResult.of("파이썬", Arrays.asList("Python", "파이썬")) // count: 2
+        );
+        AnalysisResults analysisResults = AnalysisResults.of(results);
+
+        // when
+        List<String> sharedKeywords = analysisResults.findSharedKeywords(4);
+
+        // then
+        assertThat(sharedKeywords).isEmpty();
+    }
+
+    @Test
+    void findSharedKeywords_빈_결과에서_조회시_빈_리스트_반환() {
+        // given
+        AnalysisResults emptyResults = AnalysisResults.empty();
+
+        // when
+        List<String> sharedKeywords = emptyResults.findSharedKeywords(1);
+
+        // then
+        assertThat(sharedKeywords).isEmpty();
+    }
+
+    @Test
+    void findReferenceNames_필터링_정상_동작() {
+        // given
+        List<AnalysisResult> results = Arrays.asList(
+                AnalysisResult.of("자바", Arrays.asList("Java", "JAVA", "자바")), // count: 3
+                AnalysisResult.of("파이썬", Arrays.asList("Python", "파이썬")), // count: 2
+                AnalysisResult.of("C#", Collections.singletonList("C#")) // count: 1
+        );
+        AnalysisResults analysisResults = AnalysisResults.of(results);
+
+        // when
+        List<String> referenceNames = analysisResults.findReferenceNames(3);
+
+        // then
+        assertThat(referenceNames).containsExactly("자바");
+    }
+
+    @Test
+    void findReferenceNames_해당하는_결과가_없으면_빈_리스트_반환() {
+        // given
+        List<AnalysisResult> results = Arrays.asList(
+                AnalysisResult.of("자바", Arrays.asList("Java", "JAVA")), // count: 2
+                AnalysisResult.of("파이썬", Arrays.asList("Python", "파이썬")) // count: 2
+        );
+        AnalysisResults analysisResults = AnalysisResults.of(results);
+
+        // when
+        List<String> referenceNames = analysisResults.findReferenceNames(3);
+
+        // then
+        assertThat(referenceNames).isEmpty();
+    }
+
+    @Test
+    void findReferenceNames_빈_결과에서_조회시_빈_리스트_반환() {
+        // given
+        AnalysisResults emptyResults = AnalysisResults.empty();
+
+        // when
+        List<String> referenceNames = emptyResults.findReferenceNames(1);
+
+        // then
+        assertThat(referenceNames).isEmpty();
+    }
+}

--- a/src/test/java/com/team6/team6/keyword/service/SimulatedLatencyKeywordManager.java
+++ b/src/test/java/com/team6/team6/keyword/service/SimulatedLatencyKeywordManager.java
@@ -70,5 +70,10 @@ public class SimulatedLatencyKeywordManager extends KeywordManager {
         public List<String> findReferenceNamesByRoomId(Long roomId, Integer limit) {
             return List.of();
         }
+
+        @Override
+        public void deleteByRoomId(Long roomId) {
+            return;
+        }
     }
 }

--- a/src/test/java/com/team6/team6/keyword/service/SimulatedLatencyKeywordManager.java
+++ b/src/test/java/com/team6/team6/keyword/service/SimulatedLatencyKeywordManager.java
@@ -42,6 +42,10 @@ public class SimulatedLatencyKeywordManager extends KeywordManager {
         public List<String> getKeywords(Long roomId) {
             return List.of();
         }
+
+        @Override
+        public void deleteKeywordsByRoomId(Long roomId) {
+        }
     }
 
     private static class MockKeywordSimilarityAnalyser implements KeywordSimilarityAnalyser {


### PR DESCRIPTION
# 🔨 작업 사항 
전환한 인터페이스는 아래와 같습니다.
- KeywordStore: 방별 키워드 저장 store
- KeywordLockManager: 질문 생성 요청에 대한 동시성 제어를 위한 Lock 매니저
- AnalysisResultStore: 분석 결과를 저장하기 위한 Store

## KeywordStore Redis로 전환
전환 과정에서 발생할 수 있는 동시성 이슈를 해결했습니다.
### Before
```java
@Override 
public void saveKeyword(Long roomId, String keyword) {
    String key = generateKey(roomId);
    List<String> keywords = getKeywords(roomId);
    keywords.add(keyword);
    redisTemplate.opsForValue().set(key, keywords);
}

@Override
public List<String> getKeywords(Long roomId) {
    String key = generateKey(roomId);
    List<String> keywords = 
	    (List<String>) redisTemplate.opsForValue().get(key);
    return keywords != null ? keywords : new ArrayList<>();
}
```

`문제상황`
- 키워드 추가에 대해 원자성이 보장되지 않음
- 조회 -> 수정 -> 저장으로 인해 동시성 이슈가 발생할 수 있음

`해결방법`
 - `opsForList()`를 활용해 해결
- 하나의 추가 동작으로 원자성 보장

### After
```java
@Override  
public void saveKeyword(Long roomId, String keyword) {  
    String key = generateKey(roomId);  
    redisTemplate.opsForList().rightPush(key, keyword);  
}

@Override
private List<String> getKeywords(Long roomId) {  
    String key = generateKey(roomId);  
    List<String> result = 
	    redisTemplate.opsForList().range(key, 0, -1);  
    return result != null ? result : new ArrayList<>();  
}
```

## KeywordLockManager Redis로 전환
```java
@Component
@Profile("!test")
@RequiredArgsConstructor
public class RedisKeywordLockManager implements KeywordLockManager {

    private final RedisTemplate<String, String> redisTemplate;
    private static final String LOCK_PREFIX = "keyword_lock:";
    private static final long DEFAULT_LOCK_TIMEOUT = 10; // 10초 후 자동 해제

    @Override
    public boolean tryLock(String keyword) {
        String lockKey = LOCK_PREFIX + keyword;
        return Boolean.TRUE.equals(
                redisTemplate.opsForValue()
                        .setIfAbsent(lockKey, "locked", DEFAULT_LOCK_TIMEOUT, TimeUnit.SECONDS)
        );
    }

    @Override
    public void unlock(String keyword) {
        String lockKey = LOCK_PREFIX + keyword;
        redisTemplate.delete(lockKey);
    }
}
```
- 기존에 별도의 timeout 지정이 안되어 있어서 이에 대한 논의가 필요할 것 같습니다.
- 임의로 10초 timeout 지정했습니다.

## AnalysisResultStore Redis로 전환
### 직렬화/역직렬화 문제 해결
`문제상황(Before)`
```java
public class RedisAnalysisResultStore implements AnalysisResultStore {  
  
    private static final String KEY_PREFIX = "analysis_result:";  
    private final RedisTemplate<String, Object> redisTemplate;

    @Override  
    public List<AnalysisResult> findByRoomId(Long roomId) {  
        String key = generateKey(roomId);  
        List<AnalysisResult> results = (List<AnalysisResult>) redisTemplate.opsForValue().get(key);  
        return results != null ? results : new ArrayList<>();  
    }
}
```
- RedisTemplate<String, Object>를 사용하여 List<AnalysisResult>를 저장하고 조회할 때, 역직렬화 과정에서 ClassCastException 또는 Jackson 관련 예외 발생

`해결방법`
- `List<AnalysisResult>`를 `AnalysisResults`일급 컬렉션으로 리팩토링
- 별도의 `redisTemplate`을 Bean으로 등록해 역직렬화

① Jackson2JsonRedisSerializer 사용 (선택)
- 특정 클래스 타입에 대해 명확하게 직렬화/역직렬화
- `@class` 메타데이터 미포함 → 클라이언트로 반환할 JSON이 깔끔
- 타입이 고정되므로 재사용성은 낮지만 안정성과 가독성 높음

② GenericJackson2JsonRedisSerializer 사용 (미선택)
- 다양한 타입 직렬화 가능
- `@class` 포함으로 타입 추론 가능하나,
  → JSON 응답이 지저분하고 무거움
  → 패키지 변경 시 역직렬화 실패 위험 있음

> 클라이언트에게 직접 JSON을 반환하는 구조이므로, Jackson2JsonRedisSerializer를 선택했습니다.

**After**
```java
@Bean  
public RedisTemplate<String, AnalysisResults> analysisResultsRedisTemplate(
        RedisConnectionFactory connectionFactory) {
    
    RedisTemplate<String, AnalysisResults> template = new RedisTemplate<>();
    
    Jackson2JsonRedisSerializer<AnalysisResults> serializer =
            new Jackson2JsonRedisSerializer<>(AnalysisResults.class);
    
    template.setConnectionFactory(connectionFactory);
    template.setKeySerializer(new StringRedisSerializer());
    template.setValueSerializer(serializer);
    
    return template;
}
```
- AnalysisResults 전용 RedisTemplate 빈 등록
- 클린 JSON 응답 유지 + 타입 안정성 확보

## AnalysisResults 일급 컬렉션 도입 및 Store 로직 리팩토링
`문제상황`
- List<AnalysisResult>를 직접 다루면서 도메인 로직이 Store 구현체에 분산되어 있었음
- 테스트와 재사용이 어렵고, 관련 로직이 분산되어 응집도가 낮은 구조
ex) sharedKeywords, referenceNames 추출과 같은 분석 로직이 Store에 직접 작성됨

`해결방법`
- `AnalysisResults` 일급 컬렉션 도입
```java
public record AnalysisResults(List<AnalysisResult> results) implements Serializable {
    
    public static AnalysisResults of(List<AnalysisResult> results) {
        return new AnalysisResults(results);
    }

    public static AnalysisResults empty() {
        return new AnalysisResults(new ArrayList<>());
    }

    public List<String> findSharedKeywords(Integer requiredAgreements) {
        ...
    }

    public List<String> findReferenceNames(Integer requiredAgreements) {
        ...
    }
}
```
- `List<AnalysisResult>`를 감싸는 도메인 중심 객체 `AnalysisResults` 도입
- 관련 비즈니스 로직(sharedKeywords, referenceNames)을 내부 메서드로 이동
- 도메인 로직의 응집도 강화 및 객체지향적 구조로 개선