### PR TITLE
질문 생성 Facade 객체 도입

### DIFF
--- a/src/main/java/com/team6/team6/keyword/domain/GlobalKeywordManager.java
+++ b/src/main/java/com/team6/team6/keyword/domain/GlobalKeywordManager.java
@@ -5,6 +5,7 @@ import com.team6.team6.keyword.domain.repository.KeywordGroupRepository;
 import com.team6.team6.keyword.dto.AnalysisResult;
 import com.team6.team6.keyword.entity.GlobalKeyword;
 import com.team6.team6.keyword.entity.KeywordGroup;
+import com.team6.team6.question.service.QuestionGenerationFacade;
 import com.team6.team6.question.service.QuestionService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,7 +27,7 @@ public class GlobalKeywordManager {
     private final KeywordPreprocessor keywordPreprocessor;
     private final GlobalKeywordRepository globalKeywordRepository;
     private final KeywordGroupRepository keywordGroupRepository;
-    private final QuestionService questionService;
+    private final QuestionGenerationFacade questionGenerationFacade;
 
     // 키워드 정규화: 분석 결과의 키워드를 전처리하여 일관된 형식으로 저장
     @Transactional
@@ -83,7 +84,7 @@ public class GlobalKeywordManager {
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-                questionService.generateQuestions(preprocessedNewKeyword, newGroup);
+                questionGenerationFacade.generateQuestions(preprocessedNewKeyword, newGroup);
             }
         });
     }

--- a/src/main/java/com/team6/team6/question/service/QuestionGenerationFacade.java
+++ b/src/main/java/com/team6/team6/question/service/QuestionGenerationFacade.java
@@ -1,0 +1,51 @@
+package com.team6.team6.question.service;
+
+import com.team6.team6.keyword.entity.KeywordGroup;
+import com.team6.team6.question.domain.KeywordLockManager;
+import com.team6.team6.question.domain.QuestionGenerator;
+import com.team6.team6.question.domain.QuestionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class QuestionGenerationFacade {
+
+    private final QuestionRepository questionRepository;
+    private final QuestionGenerator questionGenerator;
+    private final KeywordLockManager lockManager;
+    private final QuestionService questionService;
+
+    @Async
+    public void generateQuestions(String keyword, KeywordGroup keywordGroup) {
+        // 1. 락을 잡기 전, DB에 이미 데이터가 있는지 간단히 확인
+        if (questionRepository.existsByKeyword(keyword)) {
+            return;
+        }
+
+        // 2. 분산 락을 시도
+        if (!lockManager.tryLock(keyword)) {
+            log.warn("키워드 '{}'에 대한 락 획득 실패", keyword);
+            return;
+        }
+
+        try {
+            // 3. 외부 API를 호출
+            log.debug("질문 생성 API 호출 시작: {}", keyword);
+            List<String> generated = questionGenerator.generateQuestions(keyword);
+            log.debug("생성된 질문 수: {}", generated.size());
+
+            // 4. 생성된 데이터를 DB에 저장하기 위해 트랜잭션 메소드 호출
+            questionService.saveNewQuestions(keyword, generated, keywordGroup);
+        } finally {
+            // 5. 작업이 성공하든 실패하든, 락을 반드시 해제
+            lockManager.unlock(keyword);
+            log.info("키워드 '{}' 락 해제", keyword);
+        }
+    }
+}

--- a/src/main/java/com/team6/team6/question/service/QuestionService.java
+++ b/src/main/java/com/team6/team6/question/service/QuestionService.java
@@ -3,19 +3,14 @@ package com.team6.team6.question.service;
 import com.team6.team6.global.error.exception.NotFoundException;
 import com.team6.team6.keyword.domain.KeywordPreprocessor;
 import com.team6.team6.keyword.entity.KeywordGroup;
-import com.team6.team6.question.domain.KeywordLockManager;
-import com.team6.team6.question.domain.QuestionGenerator;
 import com.team6.team6.question.domain.QuestionRepository;
 import com.team6.team6.question.domain.Questions;
 import com.team6.team6.question.dto.QuestionResponse;
 import com.team6.team6.question.entity.Question;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.util.List;
 
@@ -27,30 +22,27 @@ public class QuestionService {
     private static final int DEFAULT_QUESTION_COUNT = 10;
 
     private final QuestionRepository questionRepository;
-    private final QuestionGenerator questionGenerator;
-    private final KeywordLockManager lockManager;
     private final KeywordPreprocessor keywordPreprocessor;
 
     @Transactional
-    @Async
-    public void generateQuestions(String keyword, KeywordGroup keywordGroup) {
-        log.info("질문 생성 시작: 키워드={}, 그룹ID={}", keyword, keywordGroup.getId());
+    public void saveNewQuestions(String keyword, List<String> generated, KeywordGroup keywordGroup) {
+        log.info("질문 저장 시작: 키워드={}", keyword);
 
-        if (questionRepository.existsByKeyword(keyword) || !lockManager.tryLock(keyword)) {
+        // Double-Checked Locking: 락을 획득하고 이 트랜잭션이 시작되기까지의 짧은 시간 동안
+        // 다른 스레드가 데이터를 이미 저장했을 수 있으므로, 최종적으로 한 번 더 확인
+        if (questionRepository.existsByKeyword(keyword)) {
+            log.warn("이미 질문이 존재하여 저장하지 않음: 키워드={}", keyword);
             return;
         }
 
-        log.debug("질문 생성 API 호출 시작: {}", keyword);
-        List<String> generated = questionGenerator.generateQuestions(keyword);
-        log.debug("생성된 질문 수: {}", generated.size());
         List<Question> questions = generated.stream()
                 .map(q -> Question.of(keyword, q, keywordGroup))
                 .toList();
         questionRepository.saveAll(questions);
-        log.info("질문 생성 완료: 키워드={}, 생성된 질문 수={}", keyword, questions.size());
-        unlockAfterCommit(keyword);
+        log.info("질문 저장 완료: 키워드={}, 생성된 질문 수={}", keyword, questions.size());
     }
 
+    @Transactional(readOnly = true)
     public List<QuestionResponse> getRandomQuestions(String keyword) {
         String preprocessedKeyword = keywordPreprocessor.preprocess(keyword);
         Questions questions = Questions.of(questionRepository.findAllByKeyword(preprocessedKeyword));
@@ -60,22 +52,5 @@ public class QuestionService {
         return questions.getRandomSubset(DEFAULT_QUESTION_COUNT).stream()
                 .map(QuestionResponse::from)
                 .toList();
-    }
-
-    private void unlockAfterCommit(String keyword) {
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                lockManager.unlock(keyword);
-            }
-
-            @Override
-            public void afterCompletion(int status) {
-                // 커밋이 아닌 종료(ex. rollback)인 경우에도 안전하게 락 해제
-                if (status != STATUS_COMMITTED) {
-                    lockManager.unlock(keyword);
-                }
-            }
-        });
     }
 }

--- a/src/test/java/com/team6/team6/keyword/domain/GlobalKeywordManagerTest.java
+++ b/src/test/java/com/team6/team6/keyword/domain/GlobalKeywordManagerTest.java
@@ -5,7 +5,7 @@ import com.team6.team6.keyword.domain.repository.KeywordGroupRepository;
 import com.team6.team6.keyword.dto.AnalysisResult;
 import com.team6.team6.keyword.entity.GlobalKeyword;
 import com.team6.team6.keyword.entity.KeywordGroup;
-import com.team6.team6.question.service.QuestionService;
+import com.team6.team6.question.service.QuestionGenerationFacade;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,7 +34,7 @@ class GlobalKeywordManagerTest {
     private KeywordGroupRepository keywordGroupRepository;
 
     @Mock
-    private QuestionService questionService;
+    private QuestionGenerationFacade generationFacade;
 
     private GlobalKeywordManager globalKeywordManager;
 
@@ -51,7 +51,7 @@ class GlobalKeywordManagerTest {
                 keywordPreprocessor,
                 globalKeywordRepository,
                 keywordGroupRepository,
-                questionService
+                generationFacade
         );
     }
 
@@ -66,7 +66,7 @@ class GlobalKeywordManagerTest {
 
         // then
         verify(globalKeywordRepository, never()).findByKeyword(anyString());
-        verify(questionService, never()).generateQuestions(anyString(), any(KeywordGroup.class));
+        verify(generationFacade, never()).generateQuestions(anyString(), any(KeywordGroup.class));
     }
 
     @Test
@@ -95,7 +95,7 @@ class GlobalKeywordManagerTest {
             softly.assertThat(savedKeyword.getKeyword()).isEqualTo("java");
             softly.assertThat(savedKeyword.getKeywordGroup()).isEqualTo(frameworkGroup);
         });
-        verify(questionService, never()).generateQuestions(anyString(), any(KeywordGroup.class));
+        verify(generationFacade, never()).generateQuestions(anyString(), any(KeywordGroup.class));
     }
 
     @Test
@@ -124,7 +124,7 @@ class GlobalKeywordManagerTest {
         verify(globalKeywordRepository, never()).bulkUpdateKeywordGroups(any(), anyCollection());
         // 키워드 저장도 발생하지 않음
         verify(globalKeywordRepository, never()).save(any(GlobalKeyword.class));
-        verify(questionService, never()).generateQuestions(anyString(), any(KeywordGroup.class));
+        verify(generationFacade, never()).generateQuestions(anyString(), any(KeywordGroup.class));
     }
 
     @Test
@@ -149,6 +149,6 @@ class GlobalKeywordManagerTest {
 
         // then
         verify(globalKeywordRepository).bulkUpdateKeywordGroups(javaGroup, Set.of(springGroup));
-        verify(questionService, never()).generateQuestions(anyString(), any(KeywordGroup.class));
+        verify(generationFacade, never()).generateQuestions(anyString(), any(KeywordGroup.class));
     }
 }

--- a/src/test/java/com/team6/team6/question/service/QuestionServiceAsyncTest.java
+++ b/src/test/java/com/team6/team6/question/service/QuestionServiceAsyncTest.java
@@ -38,6 +38,8 @@ class QuestionServiceAsyncTest {
     @MockitoSpyBean
     private QuestionRepository questionRepository;
     @Autowired
+    private QuestionGenerationFacade generationFacade;
+    @Autowired
     private QuestionService questionService;
 
     @Test
@@ -48,7 +50,7 @@ class QuestionServiceAsyncTest {
 
         // when
         long startTime = System.currentTimeMillis();
-        questionService.generateQuestions(keyword, null);
+        generationFacade.generateQuestions(keyword, null);
         long elapsed = System.currentTimeMillis() - startTime;
 
         // then
@@ -73,7 +75,7 @@ class QuestionServiceAsyncTest {
             try {
                 ready.countDown();
                 start.await();
-                questionService.generateQuestions(keyword, mockGroup);  // mock 전달
+                generationFacade.generateQuestions(keyword, mockGroup);  // mock 전달
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
             }


### PR DESCRIPTION
## 기존 코드 문제점
- **트랜잭션 범위**: 외부 API 호출, DB 저장 등 모든 과정이 하나의 트랜잭션으로 묶여 있었음
- **DB 커넥션 점유 시간**: 외부 API 호출 시간 + DB 저장 시간 만큼 DB 커넥션을 매우 길게 점유
- **역할과 책임**: QuestionService가 동시성 제어, 외부 통신, 데이터 저장 등 너무 많은 책임을 가졌음
- **성능 및 안정성**: DB 커넥션 풀 고갈로 인해 시스템 전체가 멈출 수 있는 심각한 위험이 존재

## 해결 방법
**Question Generation Facade 객체 도입**
```java
public class QuestionGenerationFacade {  
  
    private final QuestionRepository questionRepository;  
    private final QuestionGenerator questionGenerator;  
    private final KeywordLockManager lockManager;  
    private final QuestionService questionService;  
  
    @Async  
    public void generateQuestions(String keyword, KeywordGroup keywordGroup) {  
        // 1. 락을 잡기 전, DB에 이미 데이터가 있는지 간단히 확인  
        if (questionRepository.existsByKeyword(keyword)) {  
            return;  
        }  
  
        // 2. 분산 락을 시도  
        if (!lockManager.tryLock(keyword)) {  
            log.warn("키워드 '{}'에 대한 락 획득 실패", keyword);  
            return;  
        }  
  
        try {  
            // 3. 외부 API를 호출  
            log.debug("질문 생성 API 호출 시작: {}", keyword);  
            List<String> generated = questionGenerator.generateQuestions(keyword);  
            log.debug("생성된 질문 수: {}", generated.size());  
  
            // 4. 생성된 데이터를 DB에 저장하기 위해 트랜잭션 메소드 호출  
            questionService.saveNewQuestions(keyword, generated, keywordGroup);  
        } finally {  
            // 5. 작업이 성공하든 실패하든, 락을 반드시 해제  
            lockManager.unlock(keyword);  
            log.info("키워드 '{}' 락 해제", keyword);  
        }  
    }  
}
```
- **트랜잭션 범위**: 외부 API 호출은 트랜잭션 밖에서 실행되고, DB 저장은 별도의 짧은 트랜잭션으로 분리
- **DB 커넥션 점유 시간**: DB 저장 시간 만큼만 커넥션을 짧게 점유
- **역할과 책임**: 아래와 같이 역할과 책임 명확하게 분리
	- Facade: 전체 흐름 제어 
	- Service: 데이터 영속성
- **성능 및 안정성**: DB 커넥션을 효율적으로 사용해 안정성이 크게 향상되고, 시스템 전체 처리량이 증가
	