### PR TITLE
투표 결과에 투표자, 정답자 캐릭터 타입 추가

### DIFF
--- a/src/main/java/com/team6/team6/tmi/dto/TmiSubmitRequest.java
+++ b/src/main/java/com/team6/team6/tmi/dto/TmiSubmitRequest.java
@@ -9,6 +9,6 @@ public record TmiSubmitRequest(
 ) {
     public TmiSubmitServiceReq toServiceRequest(UserPrincipal userPrincipal) {
         return TmiSubmitServiceReq.of(tmiContent, userPrincipal.getRoomKey(),
-                userPrincipal.getRoomId(), userPrincipal.getId(), userPrincipal.getNickname());
+                userPrincipal.getRoomId(), userPrincipal.getId(), userPrincipal.getNickname(), userPrincipal.getCharacter());
     }
 }

--- a/src/main/java/com/team6/team6/tmi/dto/TmiSubmitServiceReq.java
+++ b/src/main/java/com/team6/team6/tmi/dto/TmiSubmitServiceReq.java
@@ -1,14 +1,16 @@
 package com.team6.team6.tmi.dto;
 
+import com.team6.team6.member.entity.CharacterType;
 import com.team6.team6.tmi.entity.TmiSubmission;
 
-public record TmiSubmitServiceReq(String tmiContent, String roomKey, Long roomId, Long memberId, String memberName) {
+public record TmiSubmitServiceReq(String tmiContent, String roomKey, Long roomId, Long memberId, String memberName,
+                                  CharacterType characterType) {
 
-    public static TmiSubmitServiceReq of(String tmiContent, String roomKey, Long roomId, Long memberId, String memberName) {
-        return new TmiSubmitServiceReq(tmiContent, roomKey, roomId, memberId, memberName);
+    public static TmiSubmitServiceReq of(String tmiContent, String roomKey, Long roomId, Long memberId, String memberName, CharacterType characterType) {
+        return new TmiSubmitServiceReq(tmiContent, roomKey, roomId, memberId, memberName, characterType);
     }
 
     public TmiSubmission toEntity() {
-        return TmiSubmission.create(roomId, memberId, memberName, tmiContent);
+        return TmiSubmission.create(roomId, memberId, memberName, tmiContent, characterType);
     }
 }

--- a/src/main/java/com/team6/team6/tmi/dto/TmiVoteRequest.java
+++ b/src/main/java/com/team6/team6/tmi/dto/TmiVoteRequest.java
@@ -12,6 +12,8 @@ public record TmiVoteRequest(
                 roomKey,
                 userPrincipal.getRoomId(),
                 userPrincipal.getNickname(),
+                userPrincipal.getId(),
+                userPrincipal.getCharacter(),
                 this.votedMemberName
         );
     }

--- a/src/main/java/com/team6/team6/tmi/dto/TmiVoteServiceReq.java
+++ b/src/main/java/com/team6/team6/tmi/dto/TmiVoteServiceReq.java
@@ -1,5 +1,6 @@
 package com.team6.team6.tmi.dto;
 
+import com.team6.team6.member.entity.CharacterType;
 import lombok.Builder;
 
 @Builder
@@ -7,13 +8,18 @@ public record TmiVoteServiceReq(
         String roomKey,
         Long roomId,
         String voterName,
+        Long voterId,
+        CharacterType voterCharacterType,
         String votedMemberName
 ) {
-    public static TmiVoteServiceReq of(String roomKey, Long roomId, String voterName, String votedMemberName) {
+    public static TmiVoteServiceReq of(String roomKey, Long roomId, String voterName, Long voterId,
+                                       CharacterType voterCharacterType, String votedMemberName) {
         return TmiVoteServiceReq.builder()
                 .roomKey(roomKey)
                 .roomId(roomId)
                 .voterName(voterName)
+                .voterId(voterId)
+                .voterCharacterType(voterCharacterType)
                 .votedMemberName(votedMemberName)
                 .build();
     }

--- a/src/main/java/com/team6/team6/tmi/dto/TmiVotingPersonalResult.java
+++ b/src/main/java/com/team6/team6/tmi/dto/TmiVotingPersonalResult.java
@@ -1,11 +1,15 @@
 package com.team6.team6.tmi.dto;
 
+import com.team6.team6.member.entity.CharacterType;
+
 import java.util.Map;
 
 public record TmiVotingPersonalResult(
         String tmiContent,
         String correctAnswer,
+        CharacterType answerMemberCharacterType,
         String myVote,
+        CharacterType myCharacterType,
         boolean isCorrect,
         Map<String, Long> votingResults,
         int round
@@ -13,11 +17,14 @@ public record TmiVotingPersonalResult(
     public static TmiVotingPersonalResult of(
             String tmiContent,
             String correctAnswer,
+            CharacterType answerMemberCharacterType,
             String myVote,
+            CharacterType myCharacterType,
             boolean isCorrect,
             Map<String, Long> votingResults,
             int round
     ) {
-        return new TmiVotingPersonalResult(tmiContent, correctAnswer, myVote, isCorrect, votingResults, round);
+        return new TmiVotingPersonalResult(tmiContent, correctAnswer, answerMemberCharacterType,
+                myVote, myCharacterType, isCorrect, votingResults, round);
     }
 }

--- a/src/main/java/com/team6/team6/tmi/entity/TmiSubmission.java
+++ b/src/main/java/com/team6/team6/tmi/entity/TmiSubmission.java
@@ -1,6 +1,7 @@
 package com.team6.team6.tmi.entity;
 
 import com.team6.team6.global.entity.BaseEntity;
+import com.team6.team6.member.entity.CharacterType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -21,25 +22,28 @@ public class TmiSubmission extends BaseEntity {
     private Long roomId;
     private Long memberId;
     private String memberName;
+    private CharacterType characterType;
     private String tmiContent;
     @Setter
     private Integer displayOrder;  // 랜덤 순서로 배정
 
     @Builder
-    private TmiSubmission(Long roomId, Long memberId, String memberName, String tmiContent, Integer displayOrder) {
+    private TmiSubmission(Long roomId, Long memberId, String memberName, String tmiContent, Integer displayOrder, CharacterType characterType) {
         this.roomId = roomId;
         this.memberId = memberId;
         this.memberName = memberName;
         this.tmiContent = tmiContent;
         this.displayOrder = displayOrder;
+        this.characterType = characterType;
     }
 
-    public static TmiSubmission create(Long roomId, Long memberId, String memberName, String tmiContent) {
+    public static TmiSubmission create(Long roomId, Long memberId, String memberName, String tmiContent, CharacterType characterType) {
         return TmiSubmission.builder()
                 .roomId(roomId)
                 .memberId(memberId)
                 .memberName(memberName)
                 .tmiContent(tmiContent)
+                .characterType(characterType)
                 .displayOrder(null)
                 .build();
     }

--- a/src/main/java/com/team6/team6/tmi/entity/TmiVote.java
+++ b/src/main/java/com/team6/team6/tmi/entity/TmiVote.java
@@ -1,6 +1,7 @@
 package com.team6.team6.tmi.entity;
 
 import com.team6.team6.global.entity.BaseEntity;
+import com.team6.team6.member.entity.CharacterType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -21,31 +22,45 @@ public class TmiVote extends BaseEntity {
 
     private Long roomId;
     private String voterName;              // 투표자
+    private Long voterId;
+    private CharacterType voterCharacterType;
     private String votedMemberName;        // 투표 받은 멤버
+    private Long votedMemberId;
+    private CharacterType votedCharacterType;
     private Boolean isCorrect;          // 투표가 맞았는지 여부
     private Long tmiSubmissionId;          // 투표한 TMI
     private Integer votingRound;               // 몇 번째 TMI에 대한 투표인지
 
     @Builder
-    private TmiVote(Long roomId, String voterName, String votedMemberName,
-                    Boolean isCorrect, Long tmiSubmissionId, Integer votingRound) {
+    private TmiVote(Long roomId, String voterName, Long voterId, CharacterType voterCharacterType,
+                    String votedMemberName, Long votedMemberId, CharacterType votedCharacterType,
+                    Long tmiSubmissionId, Integer votingRound, Boolean isCorrect) {
         this.roomId = roomId;
         this.voterName = voterName;
+        this.voterId = voterId;
+        this.voterCharacterType = voterCharacterType;
         this.votedMemberName = votedMemberName;
-        this.isCorrect = isCorrect;
+        this.votedMemberId = votedMemberId;
+        this.votedCharacterType = votedCharacterType;
         this.tmiSubmissionId = tmiSubmissionId;
         this.votingRound = votingRound;
+        this.isCorrect = isCorrect;
     }
 
-    public static TmiVote create(Long roomId, String voterName, String votedMemberName,
+    public static TmiVote create(Long roomId, String voterName, Long voterId, CharacterType voterCharacterType,
+                                 String votedMemberName, Long votedMemberId, CharacterType votedCharacterType,
                                  Long tmiSubmissionId, int votingRound) {
         return TmiVote.builder()
                 .roomId(roomId)
                 .voterName(voterName)
+                .voterId(voterId)
+                .voterCharacterType(voterCharacterType)
                 .votedMemberName(votedMemberName)
-                .isCorrect(null)
+                .votedMemberId(votedMemberId)
+                .votedCharacterType(votedCharacterType)
                 .tmiSubmissionId(tmiSubmissionId)
                 .votingRound(votingRound)
+                .isCorrect(null)
                 .build();
     }
 

--- a/src/main/java/com/team6/team6/tmi/service/TmiVoteService.java
+++ b/src/main/java/com/team6/team6/tmi/service/TmiVoteService.java
@@ -67,7 +67,11 @@ public class TmiVoteService {
         TmiVote vote = TmiVote.create(
                 req.roomId(),
                 req.voterName(),
+                req.voterId(),
+                req.voterCharacterType(),
                 req.votedMemberName(),
+                currentTmi.getMemberId(),
+                currentTmi.getCharacterType(),
                 currentTmi.getId(),
                 session.getCurrentVotingTmiIndex()
         );

--- a/src/main/java/com/team6/team6/tmi/service/TmiVoteService.java
+++ b/src/main/java/com/team6/team6/tmi/service/TmiVoteService.java
@@ -139,7 +139,9 @@ public class TmiVoteService {
         return TmiVotingPersonalResult.of(
                 tmi.getTmiContent(),
                 tmi.getMemberName(),
+                tmi.getCharacterType(),
                 myVote.getVotedMemberName(),
+                myVote.getVoterCharacterType(),
                 myVote.getIsCorrect(),
                 votes.getVotingResults(),
                 latestCompletedRound

--- a/src/test/java/com/team6/team6/tmi/controller/TmiControllerWebDocsTest.java
+++ b/src/test/java/com/team6/team6/tmi/controller/TmiControllerWebDocsTest.java
@@ -184,7 +184,9 @@ class TmiControllerWebDocsTest {
         TmiVotingPersonalResult result = new TmiVotingPersonalResult(
                 "누가 가장 늦게 잠들까요?",
                 "member1",
+                CharacterType.BEAR,
                 "testUser",
+                CharacterType.CHICK,
                 true,
                 Map.of("member1", 2L, "member2", 1L),
                 0
@@ -209,8 +211,10 @@ class TmiControllerWebDocsTest {
                                     fieldWithPath("status").type(JsonFieldType.STRING).description("HTTP 상태"),
                                     fieldWithPath("message").type(JsonFieldType.STRING).description("응답 메시지"),
                                     fieldWithPath("data.tmiContent").type(JsonFieldType.STRING).description("TMI 내용"),
-                                    fieldWithPath("data.correctAnswer").type(JsonFieldType.STRING).description("정답"),
+                                    fieldWithPath("data.correctAnswer").type(JsonFieldType.STRING).description("정답 멤버 이름"),
+                                    fieldWithPath("data.answerMemberCharacterType").type(JsonFieldType.STRING).description("정답 멤버 캐릭터"),
                                     fieldWithPath("data.myVote").type(JsonFieldType.STRING).description("내 투표"),
+                                    fieldWithPath("data.myCharacterType").type(JsonFieldType.STRING).description("내 투표 캐릭터"),
                                     fieldWithPath("data.isCorrect").type(JsonFieldType.BOOLEAN).description("정답 여부"),
                                     fieldWithPath("data.votingResults").type(JsonFieldType.OBJECT).description("투표 결과"),
                                     fieldWithPath("data.votingResults.*").type(JsonFieldType.NUMBER).description("각 멤버별 득표 수"),

--- a/src/test/java/com/team6/team6/tmi/domain/TmiVotesTest.java
+++ b/src/test/java/com/team6/team6/tmi/domain/TmiVotesTest.java
@@ -1,5 +1,6 @@
 package com.team6.team6.tmi.domain;
 
+import com.team6.team6.member.entity.CharacterType;
 import com.team6.team6.tmi.entity.TmiVote;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +26,7 @@ class TmiVotesTest {
         TmiVote myVote = tmiVotes.findVoteByName("voter2");
 
         // then
-        assertSoftly(softly->{
+        assertSoftly(softly -> {
             softly.assertThat(myVote.getVoterName()).isEqualTo("voter2");
             softly.assertThat(myVote.getVotedMemberName()).isEqualTo("member2");
         });
@@ -61,7 +62,7 @@ class TmiVotesTest {
         Map<String, Long> results = tmiVotes.getVotingResults();
 
         // then
-        assertSoftly(softly->{
+        assertSoftly(softly -> {
             softly.assertThat(results).hasSize(2);
             softly.assertThat(results.get("member1")).isEqualTo(3L);
             softly.assertThat(results.get("member2")).isEqualTo(1L);
@@ -69,6 +70,6 @@ class TmiVotesTest {
     }
 
     private TmiVote createTmiVote(String voterName, String votedMemberName) {
-        return TmiVote.create(1L, voterName, votedMemberName, 1L, 0);
+        return TmiVote.create(1L, voterName, 1L, CharacterType.PIG, votedMemberName, 1L, CharacterType.BEAR, 1L, 0);
     }
 }

--- a/src/test/java/com/team6/team6/tmi/domain/repository/TmiVoteRepositoryTest.java
+++ b/src/test/java/com/team6/team6/tmi/domain/repository/TmiVoteRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.team6.team6.tmi.domain.repository;
 
+import com.team6.team6.member.entity.CharacterType;
 import com.team6.team6.tmi.entity.TmiVote;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +23,7 @@ class TmiVoteRepositoryTest {
     @Test
     void 투표자_중복_투표_테스트() {
         // given
-        TmiVote vote = TmiVote.create(1L, "voter1", "member1", 1L, 0);
+        TmiVote vote = TmiVote.create(1L, "voter1", 1L, CharacterType.CHICK, "member1", 1L, CharacterType.BEAR, 1L, 0);
         entityManager.persistAndFlush(vote);
 
         // when & then
@@ -39,10 +40,10 @@ class TmiVoteRepositoryTest {
     @Test
     void 방의_모든_라운드_투표_조회_테스트() {
         // given
-        TmiVote vote1 = TmiVote.create(1L, "voter1", "member1", 1L, 0);
-        TmiVote vote2 = TmiVote.create(1L, "voter2", "member2", 1L, 0);
-        TmiVote vote3 = TmiVote.create(1L, "voter3", "member1", 1L, 1);
-        TmiVote vote4 = TmiVote.create(2L, "voter4", "member1", 1L, 0);
+        TmiVote vote1 = TmiVote.create(1L, "voter1", 1L, CharacterType.CHICK, "member1", 1L, CharacterType.BEAR, 1L, 0);
+        TmiVote vote2 = TmiVote.create(1L, "voter2", 2L, CharacterType.RABBIT, "member2", 1L, CharacterType.BEAR, 1L, 0);
+        TmiVote vote3 = TmiVote.create(1L, "voter3", 3L, CharacterType.PANDA, "member1", 1L, CharacterType.BEAR, 1L, 0);
+        TmiVote vote4 = TmiVote.create(2L, "voter4", 4L, CharacterType.PIG, "member1", 1L, CharacterType.BEAR, 1L, 0);
 
         entityManager.persistAndFlush(vote1);
         entityManager.persistAndFlush(vote2);
@@ -54,9 +55,9 @@ class TmiVoteRepositoryTest {
 
         // then
         assertSoftly(softly -> {
-            softly.assertThat(votes).hasSize(2);
+            softly.assertThat(votes).hasSize(3);
             softly.assertThat(votes).extracting(TmiVote::getVoterName)
-                    .containsExactlyInAnyOrder("voter1", "voter2");
+                    .containsExactlyInAnyOrder("voter1", "voter2", "voter3");
         });
     }
 }

--- a/src/test/java/com/team6/team6/tmi/service/TmiSessionServiceTest.java
+++ b/src/test/java/com/team6/team6/tmi/service/TmiSessionServiceTest.java
@@ -1,5 +1,6 @@
 package com.team6.team6.tmi.service;
 
+import com.team6.team6.member.entity.CharacterType;
 import com.team6.team6.tmi.domain.repository.TmiSessionRepository;
 import com.team6.team6.tmi.domain.repository.TmiSubmissionRepository;
 import com.team6.team6.tmi.domain.repository.TmiVoteRepository;
@@ -187,16 +188,20 @@ class TmiSessionServiceTest {
         when(tmiSubmissionRepository.findAllByRoomId(1L))
                 .thenReturn(List.of(submission1, submission2, submission3));
 
-        // 투표 데이터 생성
-        TmiVote vote1 = TmiVote.create(1L, "member1", "member2", submission2.getId(), 1);
-        vote1.changeIsCorrect("member2"); // 맞춤
-        TmiVote vote2 = TmiVote.create(1L, "member2", "member1", submission1.getId(), 0);
-        vote2.changeIsCorrect("member1"); // 맞춤
-        TmiVote vote3 = TmiVote.create(1L, "member3", "member1", submission1.getId(), 0);
-        vote3.changeIsCorrect("member1"); // 맞춤
-        TmiVote vote4 = TmiVote.create(1L, "member1", "member1", submission3.getId(), 2);
-        vote4.changeIsCorrect("member3"); // 틀림 (member3의 TMI를 틀림)
-        TmiVote vote5 = TmiVote.create(1L, "member2", "member1", submission3.getId(), 2);
+        TmiVote vote1 = TmiVote.create(1L, "member1", 1L, CharacterType.BEAR, "member2", 2L, CharacterType.BEAR, submission2.getId(), 1);
+        vote1.changeIsCorrect("member2");
+
+        TmiVote vote2 = TmiVote.create(1L, "member2", 2L, CharacterType.RABBIT, "member1", 1L, CharacterType.BEAR, submission1.getId(), 0);
+        vote2.changeIsCorrect("member1");
+
+        TmiVote vote3 = TmiVote.create(1L, "member3", 3L, CharacterType.FOX, "member1", 1L, CharacterType.BEAR, submission1.getId(), 0);
+        vote3.changeIsCorrect("member1");
+
+        TmiVote vote4 = TmiVote.create(1L, "member1", 1L, CharacterType.CHICK, "member1", 3L, CharacterType.BEAR, submission3.getId(), 2);
+        vote4.changeIsCorrect("member3");
+
+        TmiVote vote5 = TmiVote.create(1L, "member2", 2L, CharacterType.PANDA, "member1", 3L, CharacterType.BEAR, submission3.getId(), 2);
+        vote5.changeIsCorrect("member3");
         vote5.changeIsCorrect("member3"); // 틀림 (member3의 TMI를 틀림)
         when(tmiVoteRepository.findAllByRoomId(1L))
                 .thenReturn(List.of(vote1, vote2, vote3, vote4, vote5));

--- a/src/test/java/com/team6/team6/tmi/service/TmiSubmitServiceTest.java
+++ b/src/test/java/com/team6/team6/tmi/service/TmiSubmitServiceTest.java
@@ -1,5 +1,6 @@
 package com.team6.team6.tmi.service;
 
+import com.team6.team6.member.entity.CharacterType;
 import com.team6.team6.tmi.domain.TmiMessagePublisher;
 import com.team6.team6.tmi.domain.repository.TmiSubmissionRepository;
 import com.team6.team6.tmi.dto.TmiSubmitServiceReq;
@@ -96,7 +97,7 @@ class TmiSubmitServiceTest {
 
     private TmiSubmitServiceReq createTmiRequest() {
         return new TmiSubmitServiceReq(
-                "저는 고양이를 키워요", "test-room", 1L, 1L, "test-member"
+                "저는 고양이를 키워요", "test-room", 1L, 1L, "test-member", CharacterType.BEAR
         );
     }
 }

--- a/src/test/java/com/team6/team6/tmi/service/TmiVoteServiceTest.java
+++ b/src/test/java/com/team6/team6/tmi/service/TmiVoteServiceTest.java
@@ -1,5 +1,6 @@
 package com.team6.team6.tmi.service;
 
+import com.team6.team6.member.entity.CharacterType;
 import com.team6.team6.tmi.domain.TmiMessagePublisher;
 import com.team6.team6.tmi.domain.repository.TmiSessionRepository;
 import com.team6.team6.tmi.domain.repository.TmiSubmissionRepository;
@@ -90,7 +91,7 @@ class TmiVoteServiceTest {
         submission.setDisplayOrder(0);
         tmiSubmissionRepository.save(submission);
 
-        TmiVoteServiceReq request = new TmiVoteServiceReq("room1", 1L, "voter1", "member1");
+        TmiVoteServiceReq request = new TmiVoteServiceReq("room1", 1L, "voter1", 1L, CharacterType.BEAR, "member1");
 
         // when
         tmiVoteService.submitVote(request);
@@ -147,15 +148,17 @@ class TmiVoteServiceTest {
         session.startVotingPhase();
         tmiSessionRepository.save(session);
 
-        TmiSubmission submission = createTmiSubmission(1L, "member1", "TMI1");
+        TmiSubmission submission = createTmiSubmission(1L, "member2", "TMI1");
         submission.setDisplayOrder(0);
         tmiSubmissionRepository.save(submission);
 
-        TmiVote vote1 = TmiVote.create(1L, "member1", "member1", submission.getId(), 0);
-        vote1.changeIsCorrect("member1");
-        TmiVote vote2 = TmiVote.create(1L, "member2", "member1", submission.getId(), 0);
+        TmiVote vote1 = TmiVote.create(1L, "member1", 1L, CharacterType.BEAR, "member2", 2L, CharacterType.BEAR, submission.getId(), 0);
+        vote1.changeIsCorrect("member2");
+
+        TmiVote vote2 = TmiVote.create(1L, "member2", 2L, CharacterType.RABBIT, "member1", 1L, CharacterType.BEAR, submission.getId(), 0);
         vote2.changeIsCorrect("member1");
         tmiVoteRepository.saveAll(List.of(vote1, vote2));
+
         session.processVote();
         session.processVote();
 
@@ -165,10 +168,10 @@ class TmiVoteServiceTest {
         // then
         assertSoftly(softly -> {
             softly.assertThat(result.tmiContent()).isEqualTo("TMI1");
-            softly.assertThat(result.correctAnswer()).isEqualTo("member1");
-            softly.assertThat(result.myVote()).isEqualTo("member1");
+            softly.assertThat(result.correctAnswer()).isEqualTo("member2");
+            softly.assertThat(result.myVote()).isEqualTo("member2");
             softly.assertThat(result.isCorrect()).isTrue();
-            softly.assertThat(result.votingResults().get("member1")).isEqualTo(2L);
+            softly.assertThat(result.votingResults().get("member1")).isEqualTo(1L);
         });
     }
 


### PR DESCRIPTION
### 문제 상황
- `TmiVote`와 `TmiSubmission`에서 member의 characterType을 가지고 있지 않았음
- 간단한 필드 추가도 복잡해짐

### 해결 방법
- `TmiVote`와 `TmiSubmission`에 member의 id와 캐릭터타입 추가

**TmiVotingPersonalResult 수정**
```java
public record TmiVotingPersonalResult(
        String tmiContent,
        String correctAnswer,
        CharacterType answerMemberCharacterType,
        String myVote,
        CharacterType myCharacterType,
        boolean isCorrect,
        Map<String, Long> votingResults,
        int round
) {
    public static TmiVotingPersonalResult of(
            String tmiContent,
            String correctAnswer,
            CharacterType answerMemberCharacterType,
            String myVote,
            CharacterType myCharacterType,
            boolean isCorrect,
            Map<String, Long> votingResults,
            int round
    ) {
        return new TmiVotingPersonalResult(tmiContent, correctAnswer, answerMemberCharacterType,
                myVote, myCharacterType, isCorrect, votingResults, round);
    }
}
```
- `answerMemberCharacterType`: 정답자의 캐릭터
-  `myCharacterType`: 나의 캐릭터 타입


